### PR TITLE
Add CORS headers for email capture

### DIFF
--- a/docs/email_capture.gs
+++ b/docs/email_capture.gs
@@ -1,3 +1,9 @@
+function addCorsHeaders(output) {
+  return output.setHeader('Access-Control-Allow-Origin', '*')
+               .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+               .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
 function doPost(e) {
   var data = {};
   try {
@@ -9,8 +15,8 @@ function doPost(e) {
   var email = (data.email || '').trim();
 
   var output = ContentService.createTextOutput();
-  output.setMimeType(ContentService.MimeType.JSON)
-        .setHeader('Access-Control-Allow-Origin', '*');
+  output.setMimeType(ContentService.MimeType.JSON);
+  addCorsHeaders(output);
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     output.setContent(JSON.stringify({ result: 'error', message: 'Invalid email' }));
@@ -26,5 +32,12 @@ function doPost(e) {
 
   sheet.appendRow([new Date(), email]);
   output.setContent(JSON.stringify({ result: 'success' }));
+  return output;
+}
+
+function doGet(e) {
+  var output = ContentService.createTextOutput('');
+  output.setMimeType(ContentService.MimeType.JSON);
+  addCorsHeaders(output);
   return output;
 }


### PR DESCRIPTION
## Summary
- ensure Apps Script adds CORS headers via helper
- return headers for preflight requests using `doGet`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb3f4b730832f93823399c3d9ca69