### PR TITLE
Implement AI assistant API request

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -9,8 +9,32 @@
   <header><a href="/">← Home</a></header>
   <main>
     <h1>Ai-assistant</h1>
-    <p>This page is under construction.</p>
+    <textarea id="prompt" rows="6" placeholder="Enter your prompt..."></textarea>
+    <div>
+      <button onclick="generate()">Generate</button>
+    </div>
+    <pre id="output"></pre>
   </main>
+  <script>
+    async function generate() {
+      const promptEl = document.getElementById('prompt');
+      const outputEl = document.getElementById('output');
+      const prompt = promptEl.value;
+      outputEl.textContent = 'Generating...';
+      try {
+        const res = await fetch('https://your-api-id.execute-api.region.amazonaws.com/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt })
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        outputEl.textContent = data.output;
+      } catch (err) {
+        outputEl.textContent = 'Error generating code';
+      }
+    }
+  </script>
   <footer>© 2025 Devopsia</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add interactive prompt to AI assistant page
- implement `generate()` to call API Gateway endpoint and display results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e474c3b0832f8000c64a429b44ef