### PR TITLE
Improve AI assistant syntax highlighting

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>Devopsia — Ai-assistant</title>
   <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.css">
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-hcl.min.js"></script>
 </head>
 <body>
   <header><a href="/">← Home</a></header>
@@ -14,7 +17,7 @@
       <button onclick="generate()">Generate</button>
       <div id="spinner" class="spinner" style="display:none;"></div>
     </div>
-    <pre id="output"></pre>
+    <pre><code class="language-hcl" id="output"></code></pre>
     <div>
       <button id="copy-btn" onclick="copyOutput()">📋 Copy</button>
       <span id="copy-msg" style="display:none;">Copied!</span>
@@ -37,6 +40,7 @@
         if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
         outputEl.textContent = data.output;
+        Prism.highlightElement(outputEl);
       } catch (err) {
         outputEl.textContent = 'Error generating code';
       } finally {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -35,3 +35,11 @@ header, footer {
   margin-left: 0.5rem;
   color: #059669;
 }
+
+/* Styled output container for AI assistant */
+#output {
+  display: block;
+  padding: 1rem;
+  font-family: Menlo, Monaco, "Courier New", monospace;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- embed Prism.js in AI assistant page for Terraform syntax
- highlight output using Prism
- style AI assistant output element with monospace font

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f1c58024832f94bcc3996d7f3a11