### PR TITLE
Add Firebase auth support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,34 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Devopsia — AI-Powered DevOps Automation</title>
   <link rel="stylesheet" href="/css/style.css">
+  <style>
+    /* Simple auth form styles */
+    #auth {
+      margin-top: 2rem;
+      padding: 1.5rem;
+      background: #ffffff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.06);
+      max-width: 400px;
+    }
+    #auth input {
+      display: block;
+      width: 100%;
+      margin-bottom: 1rem;
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      box-sizing: border-box;
+    }
+    #auth button {
+      margin-bottom: 0.5rem;
+    }
+    #user-status {
+      margin-top: 1rem;
+      font-weight: bold;
+      text-align: center;
+    }
+  </style>
 </head>
 <body>
   <div class="container">
@@ -17,8 +45,75 @@
       <a href="/ai-assistant/" class="card">AI Assistant</a>
       <a href="/kits/" class="card">Browse Kits</a>
     </section>
+    <section id="auth" class="card">
+      <h2>Account</h2>
+      <input type="email" id="email" placeholder="Email">
+      <input type="password" id="password" placeholder="Password">
+      <button id="login">Login</button>
+      <button id="signup">Sign Up</button>
+      <button id="logout" style="display:none">Logout</button>
+      <div id="user-status">Not logged in</div>
+    </section>
   </main>
   <footer>© 2025 Devopsia</footer>
   </div>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js';
+    import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+
+    const firebaseConfig = {
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_AUTH_DOMAIN",
+      projectId: "YOUR_PROJECT_ID",
+      appId: "YOUR_APP_ID"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+
+    const emailEl = document.getElementById('email');
+    const passwordEl = document.getElementById('password');
+    const loginBtn = document.getElementById('login');
+    const signupBtn = document.getElementById('signup');
+    const logoutBtn = document.getElementById('logout');
+    const statusEl = document.getElementById('user-status');
+
+    signupBtn.addEventListener('click', async () => {
+      const email = emailEl.value;
+      const password = passwordEl.value;
+      if (!email || !password) return;
+      try {
+        await createUserWithEmailAndPassword(auth, email, password);
+      } catch (err) {
+        alert(err.message);
+      }
+    });
+
+    loginBtn.addEventListener('click', async () => {
+      const email = emailEl.value;
+      const password = passwordEl.value;
+      if (!email || !password) return;
+      try {
+        await signInWithEmailAndPassword(auth, email, password);
+      } catch (err) {
+        alert(err.message);
+      }
+    });
+
+    logoutBtn.addEventListener('click', () => {
+      signOut(auth);
+    });
+
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        statusEl.textContent = `Logged in as ${user.email}`;
+        logoutBtn.style.display = 'block';
+      } else {
+        statusEl.textContent = 'Not logged in';
+        logoutBtn.style.display = 'none';
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement Firebase email authentication in index page
- add login/signup/logout UI
- track auth state and display user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867979efb6c832f8b97c6fc345ff4b5