### PR TITLE
Fix pricing page links

### DIFF
--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -39,7 +39,7 @@
           <li>Watermarked outputs</li>
           <li>Community access (limited)</li>
         </ul>
-        <a href="#" class="start-button block text-center bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Start Free</a>
+        <a href="/login/" class="block text-center bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Start Free</a>
       </div>
 
       <div class="relative bg-white p-6 rounded-lg shadow flex flex-col ring-2 ring-orange-500">
@@ -77,7 +77,7 @@
           <li>SSO and audit logs</li>
           <li>SLA and premium support</li>
         </ul>
-        <a href="#" class="start-button block text-center bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Contact Sales</a>
+        <a href="mailto:hello@devopsia.co" class="block text-center bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Contact Sales</a>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- point *Start Free* to the login page
- make *Contact Sales* open mail client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f421636f4832f9d188df29baa34c3