### PR TITLE
Add signup flow and redesign AI page

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -3,32 +3,41 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Devopsia — Ai-assistant</title>
+  <title>Devopsia — AI Assistant</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.css">
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-hcl.min.js"></script>
 </head>
-<body>
-  <div class="container">
-  <header><a href="/">← Home</a></header>
-  <main>
-    <div class="card">
-      <h1>Ai-assistant</h1>
-      <textarea id="prompt" rows="6" placeholder="Enter your prompt..."></textarea>
-      <div>
-        <button onclick="generate()">Generate</button>
-        <div id="spinner" class="spinner" style="display:none;"></div>
+<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
+  <header class="bg-orange-500 text-white">
+    <div class="container mx-auto flex justify-between items-center py-6">
+      <div class="text-2xl font-extrabold">Devopsia</div>
+      <nav class="space-x-8 flex items-center">
+        <a href="/" class="hover:underline text-white">Home</a>
+        <a href="/pricing/" class="hover:underline text-white">Pricing</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container mx-auto flex-grow py-12">
+    <div class="bg-gray-200 p-8 rounded-lg shadow">
+      <h1 class="text-3xl font-extrabold mb-6 text-center">AI Assistant</h1>
+      <textarea id="prompt" rows="6" placeholder="Enter your prompt..." class="w-full border border-gray-300 rounded px-4 py-2 mb-4"></textarea>
+      <div class="flex items-center mb-4">
+        <button onclick="generate()" class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded">Generate</button>
+        <div id="spinner" class="spinner ml-2" style="display:none;"></div>
       </div>
       <pre><code class="language-hcl" id="output"></code></pre>
-      <div>
-        <button id="copy-btn" onclick="copyOutput()">📋 Copy</button>
-        <span id="copy-msg" style="display:none;">Copied!</span>
+      <div class="text-right mt-4">
+        <button id="copy-btn" onclick="copyOutput()" class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded inline-block">📋 Copy</button>
+        <span id="copy-msg" class="ml-2 text-sm" style="display:none;">Copied!</span>
       </div>
     </div>
   </main>
+  <footer class="text-center py-4">© 2025 Devopsia</footer>
   <script>
     async function generate() {
       const promptEl = document.getElementById('prompt');
@@ -65,7 +74,5 @@
       });
     }
   </script>
-  <footer>© 2025 Devopsia</footer>
-  </div>
 </body>
 </html>

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -33,6 +33,9 @@
         <img src="/assets/google-icon.svg" alt="Google logo" width="20" height="20">
         <span>Sign in with Google</span>
       </button>
+      <p class="mt-4 text-center text-sm">Don't have an account?
+        <a href="/signup.html" class="text-orange-600 hover:underline">Sign up</a>
+      </p>
     </div>
   </main>
   <footer class="text-center py-4">© 2025 Devopsia</footer>
@@ -60,6 +63,7 @@
       const password = document.getElementById('login-password').value;
       try {
         await signInWithEmailAndPassword(auth, email, password);
+        window.location.href = '/ai-assistant/';
       } catch (err) {
         alert(err.message);
       }
@@ -68,6 +72,7 @@
     document.getElementById('google-login').addEventListener('click', async () => {
       try {
         await signInWithPopup(auth, provider);
+        window.location.href = '/ai-assistant/';
       } catch (err) {
         alert(err.message);
       }

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Devopsia — Sign Up</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
+  <header class="bg-orange-500 text-white">
+    <div class="container mx-auto flex justify-between items-center py-6">
+      <div class="text-2xl font-extrabold">Devopsia</div>
+      <nav class="space-x-8 flex items-center">
+        <a href="/" class="hover:underline text-white">Home</a>
+        <a href="/pricing/" class="hover:underline text-white">Pricing</a>
+      </nav>
+    </div>
+  </header>
+  <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
+    <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
+      <h1 class="text-3xl font-extrabold mb-6 text-center">Create your account</h1>
+      <form id="signup-form" class="space-y-4">
+        <input type="email" id="signup-email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <input type="password" id="signup-password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Sign Up</button>
+      </form>
+      <p class="mt-4 text-center text-sm">Already have an account? <a href="/login/" class="text-orange-600 hover:underline">Log in</a></p>
+    </div>
+  </main>
+  <footer class="text-center py-4">© 2025 Devopsia</footer>
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js';
+    import { getAuth, createUserWithEmailAndPassword } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+    import { getFirestore, doc, setDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyA0bTCMkxBeZ9RQsqWSBI92-M6fcnwGbOU",
+      authDomain: "devopsia-39ea5.firebaseapp.com",
+      projectId: "devopsia-39ea5",
+      storageBucket: "devopsia-39ea5.firebasestorage.app",
+      messagingSenderId: "789816052410",
+      appId: "1:789816052410:web:241ea4bd6a5b60ba855083",
+      measurementId: "G-V190R34CQD"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    const db = getFirestore(app);
+
+    document.getElementById('signup-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('signup-email').value;
+      const password = document.getElementById('signup-password').value;
+      try {
+        const cred = await createUserWithEmailAndPassword(auth, email, password);
+        await setDoc(doc(db, 'users', cred.user.uid), { email, createdAt: Date.now() });
+        window.location.href = '/ai-assistant/';
+      } catch (err) {
+        alert(err.message);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add signup page with Firestore write
- link to signup from login page and redirect on successful auth
- redirect login page after auth
- redesign AI assistant page to match site style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc028db58832f857284413a718a53