### PR TITLE
Extend signup form

### DIFF
--- a/docs/js/signup.js
+++ b/docs/js/signup.js
@@ -2,16 +2,50 @@ import { createUserWithEmailAndPassword, updateProfile } from 'https://www.gstat
 import { doc, setDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 import { auth, db } from './firebase.js';
 
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const planParam = params.get('plan');
+  const planSelect = document.getElementById('plan');
+  if (planParam && planSelect && Array.from(planSelect.options).some(o => o.value === planParam)) {
+    planSelect.value = planParam;
+  }
+
+  const locale = navigator.language || '';
+  const match = locale.match(/-([A-Z]{2})$/i);
+  const countrySelect = document.getElementById('country');
+  if (match && countrySelect) {
+    const code = match[1].toUpperCase();
+    if (Array.from(countrySelect.options).some(o => o.value === code)) {
+      countrySelect.value = code;
+    }
+  }
+});
+
 document.getElementById('signupForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const fullName = document.getElementById('fullName').value;
   const email = document.getElementById('email').value;
   const password = document.getElementById('password').value;
   const confirmPassword = document.getElementById('confirmPassword').value;
+  const plan = document.getElementById('plan').value || 'free';
+  const companyName = document.getElementById('companyName').value;
+  const teamSize = document.getElementById('teamSize').value;
+  const country = document.getElementById('country').value;
+  const role = document.getElementById('role').value;
+  const useCases = Array.from(document.getElementById('useCase').selectedOptions).map(o => o.value);
+  const preferredModel = document.getElementById('preferredModel').value;
+  const agreeTerms = document.getElementById('agreeTerms').checked;
+  const newsletter = document.getElementById('newsletter').checked;
   const errorEl = document.getElementById('signupError');
 
   if (password !== confirmPassword) {
     errorEl.textContent = 'Passwords do not match.';
+    errorEl.classList.remove('hidden');
+    return;
+  }
+
+  if (!agreeTerms) {
+    errorEl.textContent = 'You must agree to the terms.';
     errorEl.classList.remove('hidden');
     return;
   }
@@ -22,7 +56,15 @@ document.getElementById('signupForm').addEventListener('submit', async (e) => {
     await setDoc(doc(db, 'users', userCred.user.uid), {
       name: fullName,
       email: email,
-      plan: 'free',
+      plan,
+      company: companyName || null,
+      teamSize: teamSize ? Number(teamSize) : null,
+      country: country || null,
+      role: role || null,
+      useCases: useCases.length ? useCases : null,
+      preferredModel: preferredModel || null,
+      newsletterOptIn: newsletter,
+      agreedToTerms: agreeTerms,
       createdAt: serverTimestamp(),
       promptQuota: 10,
       usedPrompts: 0

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -35,6 +35,60 @@
         <input type="email" id="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
         <input type="password" id="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
         <input type="password" id="confirmPassword" placeholder="Confirm Password" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <select id="plan" class="w-full border border-gray-300 rounded px-4 py-2">
+          <option value="free">Free</option>
+          <option value="pro">Pro</option>
+          <option value="team">Team</option>
+          <option value="enterprise">Enterprise</option>
+        </select>
+
+        <details class="w-full border border-gray-300 rounded px-4 py-2">
+          <summary class="cursor-pointer font-semibold">Additional Info (optional)</summary>
+          <div class="mt-4 space-y-4">
+            <input type="text" id="companyName" placeholder="Company Name" class="w-full border border-gray-300 rounded px-4 py-2">
+            <input type="number" id="teamSize" placeholder="Team Size" class="w-full border border-gray-300 rounded px-4 py-2">
+            <select id="country" class="w-full border border-gray-300 rounded px-4 py-2">
+              <option value="">Country</option>
+              <option value="US">United States</option>
+              <option value="CA">Canada</option>
+              <option value="GB">United Kingdom</option>
+              <option value="FR">France</option>
+              <option value="DE">Germany</option>
+              <option value="IN">India</option>
+              <option value="JP">Japan</option>
+              <option value="AU">Australia</option>
+              <option value="BR">Brazil</option>
+            </select>
+            <select id="role" class="w-full border border-gray-300 rounded px-4 py-2">
+              <option value="">Role</option>
+              <option value="devops">DevOps Engineer</option>
+              <option value="sre">SRE</option>
+              <option value="manager">Manager</option>
+            </select>
+            <select id="useCase" multiple class="w-full border border-gray-300 rounded px-4 py-2">
+              <option value="infrastructure">Infrastructure generation</option>
+              <option value="automation">Automation kits</option>
+              <option value="chatops">ChatOps</option>
+            </select>
+            <select id="preferredModel" class="w-full border border-gray-300 rounded px-4 py-2">
+              <option value="">Preferred Model</option>
+              <option value="haiku">Haiku</option>
+              <option value="sonnet">Sonnet</option>
+              <option value="opus">Opus</option>
+            </select>
+          </div>
+        </details>
+
+        <label class="flex items-center">
+          <input type="checkbox" id="agreeTerms" class="mr-2" required>
+          <span>I agree to the <a href="/terms" class="text-orange-600 hover:underline">Terms</a> and <a href="/privacy" class="text-orange-600 hover:underline">Privacy Policy</a></span>
+        </label>
+
+        <label class="flex items-center">
+          <input type="checkbox" id="newsletter" class="mr-2">
+          <span>Sign me up for the newsletter</span>
+        </label>
+
         <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Create Account</button>
         <p id="signupError" class="text-red-500 text-sm hidden"></p>
       </form>


### PR DESCRIPTION
## Summary
- redesign signup form with optional collapsible section
- add fields for plan, company, team size, country, role, use cases, preferred model
- add agree to terms and newsletter checkboxes
- prefill plan from query string and country from locale
- store new fields in Firestore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fece29d28832f9e622eeab8dc094b