### PR TITLE
Fix signup checkbox alignment

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -31,7 +31,8 @@ h3 {
 }
 
 textarea,
-input {
+select,
+input:not([type="checkbox"]):not([type="radio"]) {
   width: 100%;
   max-width: 100%;
 }


### PR DESCRIPTION
## Summary
- avoid forcing 100% width on checkbox inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ad002830832f81a566ea1c509973