### PR TITLE
Add terms and privacy policy pages

### DIFF
--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Devopsia — Privacy Policy</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+</head>
+<body>
+  <div class="container">
+  <header>
+    <a href="/">← Home</a>
+    <a id="authButton" href="/login/" class="ml-4">Login</a>
+  </header>
+  <main>
+    <div class="card">
+      <h1>Privacy Policy</h1>
+      <p>This policy explains how Devopsia collects and uses your information.</p>
+      <h2>Information We Collect</h2>
+      <p>We collect the information you provide when registering, such as your email address, and logs related to your use of our services.</p>
+      <h2>How We Use Data</h2>
+      <p>Data is used to provide and improve the Devopsia platform, to communicate with you, and to secure our services.</p>
+      <h2>Cookies</h2>
+      <p>We may use cookies and similar technologies to enhance your experience and analyze usage.</p>
+      <h2>Your Rights</h2>
+      <p>If you are located in the European Union, the General Data Protection Regulation (GDPR) grants you rights to access, correct, or request deletion of your personal data. You may contact us to exercise these rights.</p>
+      <h2>Data Retention</h2>
+      <p>We retain personal data only as long as necessary for the purposes described above or as required by law.</p>
+      <h2>Changes</h2>
+      <p>We may update this Privacy Policy periodically. We will notify you of significant changes by posting the updated policy on our website.</p>
+      <h2>Contact</h2>
+      <p>For privacy questions or requests, email <a href="mailto:privacy@devopsia.com">privacy@devopsia.com</a>.</p>
+    </div>
+  </main>
+  <footer>© 2025 Devopsia</footer>
+  </div>
+  <script type="module" src="/js/firebase.js"></script>
+  <script type="module" src="/js/auth.js"></script>
+</body>
+</html>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Devopsia — Terms of Service</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+</head>
+<body>
+  <div class="container">
+  <header>
+    <a href="/">← Home</a>
+    <a id="authButton" href="/login/" class="ml-4">Login</a>
+  </header>
+  <main>
+    <div class="card">
+      <h1>Terms of Service</h1>
+      <p>Welcome to Devopsia. By accessing or using our platform you agree to the following terms. If you do not agree, you may not use the service.</p>
+      <h2>Use of Service</h2>
+      <p>Devopsia offers tooling and AI assistants to streamline DevOps workflows. You are responsible for any content or commands you submit. Do not use the service for unlawful activities.</p>
+      <h2>Accounts</h2>
+      <p>You must provide accurate registration information and maintain the security of your account. You are responsible for all activity under your credentials.</p>
+      <h2>Intellectual Property</h2>
+      <p>All Devopsia content and branding are owned by Devopsia. Using the platform does not grant you any intellectual property rights in our services or content.</p>
+      <h2>Disclaimer</h2>
+      <p>Our service is provided "as is" without warranties of any kind. We are not liable for any damages arising from your use of the platform.</p>
+      <h2>Privacy and Data</h2>
+      <p>We handle personal information as described in our <a href="/privacy">Privacy Policy</a>. Users located in the European Union have additional rights under the GDPR, including the right to request data deletion and access to stored personal data.</p>
+      <h2>Changes</h2>
+      <p>We may update these Terms from time to time. Continued use of Devopsia constitutes acceptance of the updated Terms.</p>
+      <h2>Contact</h2>
+      <p>For questions about these Terms, contact us at <a href="mailto:info@devopsia.com">info@devopsia.com</a>.</p>
+    </div>
+  </main>
+  <footer>© 2025 Devopsia</footer>
+  </div>
+  <script type="module" src="/js/firebase.js"></script>
+  <script type="module" src="/js/auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Terms of Service page with EU GDPR note
- add Privacy Policy page with GDPR rights information

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880f83647e8832fa6de23983d12d0e5