### PR TITLE
Add Tron-style footer icons

### DIFF
--- a/docs/assets/devops-handbook-monochrome.svg
+++ b/docs/assets/devops-handbook-monochrome.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12c2-4 6-4 9 0s7 4 9 0" />
+  <path d="M3 12c2 4 6 4 9 0s7-4 9 0" />
+</svg>

--- a/docs/assets/phoenix-monochrome.svg
+++ b/docs/assets/phoenix-monochrome.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3l2 4h3l-3 3 3 3-5 6-5-6 3-3-3-3h3z" />
+</svg>

--- a/docs/assets/tron-monochrome.svg
+++ b/docs/assets/tron-monochrome.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9" />
+  <circle cx="12" cy="12" r="4" />
+  <line x1="12" y1="3" x2="12" y2="7" />
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,14 @@
     </a>
   </section>
 
-  <footer class="mt-auto text-center py-4">© 2025 Devopsia</footer>
+  <footer class="mt-auto text-center py-4">
+    <div class="flex items-center justify-center space-x-6 mb-2 text-gray-800">
+      <img src="/assets/tron-monochrome.svg" alt="Tron icon" class="w-8 h-8" />
+      <img src="/assets/devops-handbook-monochrome.svg" alt="DevOps Handbook icon" class="w-8 h-8" />
+      <img src="/assets/phoenix-monochrome.svg" alt="Phoenix Project icon" class="w-8 h-8" />
+    </div>
+    © 2025 Devopsia
+  </footer>
 
   <script type="module">
     import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js';


### PR DESCRIPTION
## Summary
- add Tron-inspired monochrome icons for Tron disc, DevOps handbook and Phoenix Project
- show these icons in the home page footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68810becc620832fae162e20507d2464