### PR TITLE
Add Tron-inspired footer icons

### DIFF
--- a/docs/assets/devops-handbook-icon.svg
+++ b/docs/assets/devops-handbook-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="16" rx="2"/>
+  <path d="M7 4v16"/>
+  <path d="M3 8h18"/>
+  <circle cx="15" cy="15" r="3"/>
+  <path d="M15 12v6"/>
+  <path d="M12 15h6"/>
+</svg>

--- a/docs/assets/phoenix-project-icon.svg
+++ b/docs/assets/phoenix-project-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2l2 6h6l-4.5 3.5L17 18l-5-3-5 3 1.5-6.5L4 8h6z"/>
+</svg>

--- a/docs/assets/tron-icon.svg
+++ b/docs/assets/tron-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"/>
+  <path d="M3 12h18"/>
+  <path d="M12 3v18"/>
+  <path d="M4.5 4.5l15 15"/>
+  <path d="M19.5 4.5l-15 15"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,14 @@
     </a>
   </section>
 
-  <footer class="mt-auto text-center py-4">© 2025 Devopsia</footer>
+  <footer class="mt-auto text-center py-4">
+    <div class="flex justify-center space-x-6 mb-2">
+      <img src="/assets/tron-icon.svg" alt="Tron inspired icon" width="24" height="24">
+      <img src="/assets/devops-handbook-icon.svg" alt="DevOps Handbook icon" width="24" height="24">
+      <img src="/assets/phoenix-project-icon.svg" alt="Phoenix Project icon" width="24" height="24">
+    </div>
+    © 2025 Devopsia
+  </footer>
 
   <script type="module">
     import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js';


### PR DESCRIPTION
## Summary
- add Tron-inspired icons for the home page footer
- show the new icons in the footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68810becc620832fae162e20507d2464