### PR TITLE
Apply gradient header style

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700 font-sans">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -133,7 +133,7 @@ header, footer {
 
 /* Navigation bar with rounded corners and gradient */
 .site-header {
-  background: linear-gradient(90deg, rgba(249,115,22,0.85), rgba(234,88,12,0.85));
+  background: linear-gradient(90deg, rgba(249,115,22,0.9), rgba(249,115,22,0));
   border-radius: 0.75rem;
   color: #ffffff;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col font-sans bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/kits/index.html
+++ b/docs/kits/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -18,7 +18,7 @@
   </style>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -19,7 +19,7 @@
   <script type="module" src="/js/signup.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="bg-orange-500 text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
+  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
       <nav class="hidden md:flex space-x-4 items-center">


### PR DESCRIPTION
## Summary
- style the top banner with a translucent orange gradient and rounded corners
- use `site-header` class across pages for the banner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887518842b8832f84db1ec820c83582