### PR TITLE
Add prompt builder for Claude

### DIFF
--- a/lambda/generate.ts
+++ b/lambda/generate.ts
@@ -1,0 +1,61 @@
+import fs from 'fs/promises';
+import path from 'path';
+import fetch from 'node-fetch';
+
+export type PromptMode = 'secure' | 'optimized' | 'standard';
+
+export async function buildPrompt(userPrompt: string, promptMode: PromptMode): Promise<string> {
+  if (promptMode === 'secure') {
+    const prefixPath = path.join(__dirname, '../prompts/prefixes/secure_instructions.md');
+    const prefix = await fs.readFile(prefixPath, 'utf8');
+    return `${prefix}\n\n${userPrompt}`;
+  }
+
+  if (promptMode === 'optimized') {
+    const prefix = '[OPTIMIZATION INSTRUCTIONS – Output should be minimal, performant, and cost-aware]';
+    return `${prefix}\n\n${userPrompt}`;
+  }
+
+  return userPrompt;
+}
+
+export const handler = async (event: any) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  try {
+    if (!event.body) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing request body' }), headers };
+    }
+
+    const { prompt, promptMode = 'standard' } = JSON.parse(event.body);
+    const fullPrompt = await buildPrompt(prompt, promptMode as PromptMode);
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': process.env.CLAUDE_API_KEY || '',
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-sonnet-20240229',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: fullPrompt }]
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('Claude API request failed');
+    }
+
+    const data = await response.json();
+    const output = data?.content || '';
+
+    return { statusCode: 200, headers, body: JSON.stringify({ output }) };
+  } catch (error) {
+    console.error('Claude generation error:', error);
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Generation failed' }) };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "devopsia",
       "version": "1.0.0",
       "dependencies": {
+        "node-fetch": "^3.3.2",
         "stripe": "^12.18.0"
       }
     },
@@ -47,6 +48,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/dunder-proto": {
@@ -91,6 +101,41 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/function-bind": {
@@ -182,6 +227,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-inspect": {
@@ -301,6 +384,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "echo \"No tests defined\" && exit 0"
   },
   "dependencies": {
-    "stripe": "^12.18.0"
+    "stripe": "^12.18.0",
+    "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- add a new TypeScript lambda `generate.ts` that builds prompts using the selected mode
- include helper function `buildPrompt` that loads `secure_instructions.md` for secure mode and adds optimized prefix when needed
- send the constructed prompt to the Claude API
- install `node-fetch` for API requests

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688b58f89880832fbed690d6d6abb9d4