### PR TITLE
Restrict AI assistant to verified users

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700 font-sans" style="display:none;">
   <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -2,8 +2,10 @@ import { auth } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
 
 onAuthStateChanged(auth, user => {
-  if (!user) {
-    window.location.href = '/login/';
+  if (user && user.emailVerified) {
+    document.body.style.display = '';
+  } else {
+    window.location.replace('/login/');
   }
 });
 


### PR DESCRIPTION
## Summary
- hide AI assistant body until auth is verified
- redirect to login unless user email is verified

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b7107d74c832f9ab1cb85f901d788