### PR TITLE
Persist prompt mode preference

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -41,7 +41,7 @@
 
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">Your AI DevOps Engineer</h1>
-      <div x-data="{ promptMode: 'standard' }" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+      <div x-data="promptSettings()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
         <div>
           <label for="promptMode" class="block text-sm font-medium mb-1">Prompt Mode</label>
           <select id="promptMode" x-model="promptMode" class="w-full border rounded p-2">

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -1,13 +1,37 @@
-import { auth } from './firebase.js';
+import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+import { doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
-onAuthStateChanged(auth, user => {
-  if (user && user.emailVerified) {
-    document.body.style.display = '';
-  } else {
-    window.location.replace('/login/');
-  }
-});
+export function promptSettings() {
+  return {
+    promptMode: 'standard',
+    async init() {
+      onAuthStateChanged(auth, async user => {
+        if (user && user.emailVerified) {
+          document.body.style.display = '';
+          const prefRef = doc(db, 'users', user.uid, 'preferences');
+          try {
+            const snap = await getDoc(prefRef);
+            if (snap.exists() && snap.data().promptMode) {
+              this.promptMode = snap.data().promptMode;
+            }
+          } catch (err) {
+            console.error('Failed to load preferences', err);
+          }
+          this.$watch('promptMode', async value => {
+            try {
+              await setDoc(prefRef, { promptMode: value }, { merge: true });
+            } catch (err) {
+              console.error('Failed to save preferences', err);
+            }
+          });
+        } else {
+          window.location.replace('/login/');
+        }
+      });
+    }
+  };
+}
 
 document.getElementById('runPrompt').addEventListener('click', async () => {
   const prompt = document.getElementById('promptInput').value;


### PR DESCRIPTION
## Summary
- store `promptMode` to Firestore so user preference is remembered
- load saved prompt mode on page init via Alpine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b76eb1964832f941fb17692a89747