### PR TITLE
Add tooltip for prompt mode selection

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -41,10 +41,22 @@
 
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">Your AI DevOps Engineer</h1>
-      <div x-data="{ promptMode: 'standard' }" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-        <div>
-          <label for="promptMode" class="block text-sm font-medium mb-1">Prompt Mode</label>
-          <select id="promptMode" x-model="promptMode" class="w-full border rounded p-2">
+      <div x-data="{ 
+            promptMode: 'standard',
+            tooltipVisible: false,
+            tooltipTexts: {
+              standard: 'Standard mode for general prompts.',
+              secure: 'Secure mode ensures best practices.',
+              optimized: 'Optimized mode focuses on efficiency.'
+            }
+          }" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div class="relative">
+          <label for="promptMode" class="block text-sm font-medium mb-1 flex items-center">
+            Prompt Mode
+            <span class="ml-1 cursor-pointer text-gray-500" @mouseenter="tooltipVisible = true" @mouseleave="tooltipVisible = false">ⓘ</span>
+          </label>
+          <div x-show="tooltipVisible" x-text="tooltipTexts[promptMode]" x-cloak class="absolute left-full top-0 ml-2 w-48 p-2 text-xs text-white bg-gray-700 rounded shadow"></div>
+          <select id="promptMode" x-model="promptMode" class="w-full border rounded p-2 mt-1">
             <option value="standard">Standard</option>
             <option value="secure">Secure (best practices)</option>
             <option value="optimized">Optimized</option>


### PR DESCRIPTION
## Summary
- enhance AI Assistant with an info tooltip
- use Alpine.js to show a different message depending on the selected prompt mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b77247388832fb4bc4e2fbb17868d