### PR TITLE
Restrict AI assistant to verified users

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -10,7 +10,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700 font-sans">
+<body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
+  <div id="protected-content" class="hidden min-h-screen flex flex-col">
   <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
     <div class="max-w-6xl mx-auto flex justify-between items-center">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
@@ -57,6 +59,7 @@
     </main>
 
   <footer class="text-center py-4">© 2025 Devopsia</footer>
+  </div>
 
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -1,9 +1,15 @@
 import { auth } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
 
-onAuthStateChanged(auth, user => {
-  if (!user) {
-    window.location.href = '/login/';
+const loadingEl = document.getElementById('auth-loading');
+const contentEl = document.getElementById('protected-content');
+
+onAuthStateChanged(auth, (user) => {
+  if (user && user.emailVerified) {
+    if (loadingEl) loadingEl.classList.add('hidden');
+    if (contentEl) contentEl.classList.remove('hidden');
+  } else {
+    window.location.replace('/login/');
   }
 });
 


### PR DESCRIPTION
## Summary
- show a loading screen while verifying auth on `/ai-assistant`
- require a signed-in, email verified user before showing content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ca1a1bccc832fb413bebdc5e94617