### PR TITLE
feat: restrict secure prompt mode to pro users

### DIFF
--- a/docs/ai-assistant/index.html
+++ b/docs/ai-assistant/index.html
@@ -55,7 +55,7 @@
           </label>
           <select id="promptMode" x-model="promptMode" class="w-full border border-gray-300 rounded p-2 mt-1 bg-white text-gray-700">
             <option value="standard">Standard</option>
-            <option value="secure">🔒 Secure (best practices)</option>
+            <option value="secure" disabled>🔒 Secure (best practices)</option>
             <option value="optimized">Optimized</option>
           </select>
         </div>

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -2,6 +2,16 @@ import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
 import { doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
+let userPlan = 'free';
+
+function showToast(message) {
+  const toast = document.createElement('div');
+  toast.textContent = message;
+  toast.className = 'fixed top-4 right-4 bg-gray-800 text-white py-2 px-4 rounded shadow z-50';
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 3000);
+}
+
 const loadingEl = document.getElementById('auth-loading');
 const contentEl = document.getElementById('protected-content');
 
@@ -18,6 +28,7 @@ export function promptComponent() {
   return {
     promptMode: 'standard',
     promptDescription: '',
+    isPro: false,
     descriptions: {
       standard: 'General guidance without additional optimizations.',
       secure: 'Applies security best practices to every response.',
@@ -28,17 +39,40 @@ export function promptComponent() {
       onAuthStateChanged(auth, async (user) => {
         if (!user) return;
         const prefRef = doc(db, 'users', user.uid, 'preferences');
+        const userRef = doc(db, 'users', user.uid);
         try {
-          const snap = await getDoc(prefRef);
-          if (snap.exists() && snap.data().promptMode) {
-            this.promptMode = snap.data().promptMode;
+          const [prefSnap, planSnap] = await Promise.all([
+            getDoc(prefRef),
+            getDoc(userRef)
+          ]);
+          if (prefSnap.exists() && prefSnap.data().promptMode) {
+            this.promptMode = prefSnap.data().promptMode;
             this.promptDescription = this.descriptions[this.promptMode];
           }
+          if (planSnap.exists() && typeof planSnap.data().plan === 'string') {
+            userPlan = planSnap.data().plan.toLowerCase();
+            this.isPro = userPlan === 'pro';
+          }
         } catch (err) {
-          console.error('Failed to load prompt mode', err);
+          console.error('Failed to load user settings', err);
+        }
+
+        const secureOption = document.querySelector('#promptMode option[value="secure"]');
+        if (secureOption) {
+          secureOption.disabled = !this.isPro;
+        }
+        if (!this.isPro && this.promptMode === 'secure') {
+          this.promptMode = 'standard';
+          this.promptDescription = this.descriptions[this.promptMode];
         }
 
         this.$watch('promptMode', async (value) => {
+          if (value === 'secure' && !this.isPro) {
+            this.promptMode = 'standard';
+            this.promptDescription = this.descriptions[this.promptMode];
+            showToast('Secure mode is available on Pro only');
+            return;
+          }
           this.promptDescription = this.descriptions[value] || '';
           try {
             await setDoc(prefRef, { promptMode: value }, { merge: true });
@@ -55,6 +89,10 @@ document.getElementById('runPrompt').addEventListener('click', async () => {
   const prompt = document.getElementById('promptInput').value;
   const promptMode = document.getElementById('promptMode').value;
   const resultEl = document.getElementById('result');
+  if (promptMode === 'secure' && userPlan !== 'pro') {
+    showToast('Secure mode is available on Pro only');
+    return;
+  }
   resultEl.textContent = 'Generating...';
   try {
     const res = await fetch('https://e0wxwjllp0.execute-api.eu-north-1.amazonaws.com/prod/generate', {


### PR DESCRIPTION
## Summary
- fetch user plan from Firestore and disable Secure mode for non-pro accounts
- block non-pro submissions with a toast warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689223753dac832f8a4b283efdf6de97