### PR TITLE
Restrict secure prompt mode to Pro users

### DIFF
--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -2,11 +2,32 @@ import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
 import { doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
+let currentUserPlan = null;
+
+function showToast(message) {
+  const toast = document.createElement('div');
+  toast.textContent = message;
+  toast.className = 'fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow';
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 3000);
+}
+
 const loadingEl = document.getElementById('auth-loading');
 const contentEl = document.getElementById('protected-content');
 
-onAuthStateChanged(auth, (user) => {
+onAuthStateChanged(auth, async (user) => {
   if (user && user.emailVerified) {
+    try {
+      const userSnap = await getDoc(doc(db, 'users', user.uid));
+      currentUserPlan = userSnap.exists() ? userSnap.data().plan : null;
+      if (currentUserPlan !== 'pro') {
+        const secureOption = document.querySelector('#promptMode option[value="secure"]');
+        if (secureOption) secureOption.disabled = true;
+      }
+    } catch (err) {
+      console.error('Failed to load user plan', err);
+    }
+
     if (loadingEl) loadingEl.classList.add('hidden');
     if (contentEl) contentEl.classList.remove('hidden');
   } else {
@@ -32,6 +53,9 @@ export function promptComponent() {
           const snap = await getDoc(prefRef);
           if (snap.exists() && snap.data().promptMode) {
             this.promptMode = snap.data().promptMode;
+            if (this.promptMode === 'secure' && currentUserPlan !== 'pro') {
+              this.promptMode = 'standard';
+            }
             this.promptDescription = this.descriptions[this.promptMode];
           }
         } catch (err) {
@@ -39,6 +63,13 @@ export function promptComponent() {
         }
 
         this.$watch('promptMode', async (value) => {
+          if (value === 'secure' && currentUserPlan !== 'pro') {
+            this.promptMode = 'standard';
+            this.promptDescription = this.descriptions[this.promptMode];
+            showToast('Secure mode is available on Pro only');
+            return;
+          }
+
           this.promptDescription = this.descriptions[value] || '';
           try {
             await setDoc(prefRef, { promptMode: value }, { merge: true });
@@ -52,8 +83,13 @@ export function promptComponent() {
 }
 
 document.getElementById('runPrompt').addEventListener('click', async () => {
-  const prompt = document.getElementById('promptInput').value;
+  const prompt = document.getElementById('promptInput').value.trim();
   const promptMode = document.getElementById('promptMode').value;
+  if (promptMode === 'secure' && currentUserPlan !== 'pro') {
+    showToast('Secure mode is available on Pro only');
+    return;
+  }
+
   const resultEl = document.getElementById('result');
   resultEl.textContent = 'Generating...';
   try {


### PR DESCRIPTION
## Summary
- gate Secure mode based on Firestore `plan` and disable option for non-Pro users
- warn non-Pro users with toast and block Secure prompt submissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689223753dac832f8a4b283efdf6de97