### PR TITLE
Add reusable sidebar to AI assistant pages

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -41,6 +41,7 @@
     </div>
   </header>
 
+  <div id="sidebar-container"></div>
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">AI Assistant for Ansible</h1>
       <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
@@ -72,5 +73,6 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -41,6 +41,7 @@
     </div>
   </header>
 
+  <div id="sidebar-container"></div>
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">AI Assistant for Docker</h1>
       <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
@@ -72,5 +73,6 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -41,6 +41,7 @@
     </div>
   </header>
 
+  <div id="sidebar-container"></div>
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">AI Assistant for Helm Charts</h1>
       <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
@@ -72,5 +73,6 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -41,6 +41,7 @@
     </div>
   </header>
 
+  <div id="sidebar-container"></div>
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">AI Assistant for Kubernetes</h1>
       <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
@@ -72,5 +73,6 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -41,6 +41,7 @@
     </div>
   </header>
 
+  <div id="sidebar-container"></div>
     <main class="container mx-auto flex-grow py-12 max-w-4xl">
       <h1 class="text-3xl font-medium font-tagline mb-6 text-center">AI Assistant for YAML</h1>
       <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
@@ -72,5 +73,6 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
 </body>
 </html>

--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -1,0 +1,12 @@
+<aside class="w-64 bg-white border-r min-h-screen flex flex-col">
+  <nav id="sidebar-menu" class="flex-1 p-4 space-y-2">
+    <a href="/ai-assistant/" class="block px-2 py-1 rounded hover:bg-gray-100">Terraform</a>
+    <a href="/ai-assistant-helm/" class="block px-2 py-1 rounded hover:bg-gray-100">Helm</a>
+    <a href="/ai-assistant-k8s/" class="block px-2 py-1 rounded hover:bg-gray-100">K8s</a>
+    <a href="/ai-assistant-yaml/" class="block px-2 py-1 rounded hover:bg-gray-100">YAML</a>
+    <a href="/ai-assistant-ansible/" class="block px-2 py-1 rounded hover:bg-gray-100">Ansible</a>
+    <a href="/ai-assistant-docker/" class="block px-2 py-1 rounded hover:bg-gray-100">Docker</a>
+  </nav>
+  <div id="sidebar-user" class="p-4 border-t flex items-center space-x-2"></div>
+  <button id="sidebar-logout" class="m-4 px-4 py-2 bg-red-600 text-white rounded">Logout</button>
+</aside>

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -1,0 +1,58 @@
+import { auth } from './firebase.js';
+import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+
+async function initSidebar() {
+  const container = document.getElementById('sidebar-container');
+  if (!container) return;
+  try {
+    const res = await fetch('/components/sidebar.html');
+    if (!res.ok) throw new Error('Failed to load sidebar');
+    container.innerHTML = await res.text();
+    setupAuth();
+    highlightLink();
+    setupLogout();
+  } catch (err) {
+    console.error('Sidebar load error', err);
+  }
+}
+
+function setupAuth() {
+  const userDiv = document.getElementById('sidebar-user');
+  if (!userDiv) return;
+  onAuthStateChanged(auth, (user) => {
+    userDiv.textContent = '';
+    if (!user) return;
+    if (user.photoURL) {
+      const img = document.createElement('img');
+      img.src = user.photoURL;
+      img.alt = 'User Avatar';
+      img.referrerPolicy = 'no-referrer';
+      img.className = 'w-8 h-8 rounded-full';
+      userDiv.appendChild(img);
+    }
+    const span = document.createElement('span');
+    span.textContent = user.email || '';
+    userDiv.appendChild(span);
+  });
+}
+
+function highlightLink() {
+  const path = window.location.pathname;
+  document.querySelectorAll('#sidebar-menu a').forEach((link) => {
+    if (link.getAttribute('href') === path) {
+      link.classList.add('bg-gray-200', 'font-semibold');
+    }
+  });
+}
+
+function setupLogout() {
+  const btn = document.getElementById('sidebar-logout');
+  if (!btn) return;
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    await signOut(auth);
+    window.location.href = '/';
+  }, { once: true });
+}
+
+document.addEventListener('DOMContentLoaded', initSidebar);


### PR DESCRIPTION
## Summary
- add shared sidebar component with assistant navigation
- load sidebar on each AI assistant page and show Firebase auth user info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689359df7078832f97e0e9d25f5b200f