### PR TITLE
feat: log prompts and show history

### DIFF
--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -9,6 +9,7 @@
       <li><a href="/ai-assistant-yaml/" class="block px-2 py-1 rounded hover:bg-gray-200">YAML</a></li>
       <li><a href="/ai-assistant-ansible/" class="block px-2 py-1 rounded hover:bg-gray-200">Ansible</a></li>
       <li><a href="/ai-assistant-docker/" class="block px-2 py-1 rounded hover:bg-gray-200">Docker</a></li>
+      <li id="prompt-history-item" class="hidden"><a href="/prompt-history/" class="block px-2 py-1 rounded hover:bg-gray-200">Prompt History</a></li>
     </ul>
   </div>
   <button id="logout-btn" class="mt-6 bg-red-100 hover:bg-red-200 text-red-600 px-4 py-2 rounded w-full">

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -1,6 +1,6 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
-import { doc, getDoc, setDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+import { doc, getDoc, setDoc, collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
 let userPlan = 'free';
 
@@ -104,6 +104,19 @@ document.getElementById('runPrompt').addEventListener('click', async () => {
     if (!res.ok) throw new Error('Request failed');
     const data = await res.json();
     resultEl.textContent = data.output;
+    const user = auth.currentUser;
+    if (user) {
+      try {
+        await addDoc(collection(db, 'users', user.uid, 'prompts'), {
+          prompt,
+          mode: promptMode,
+          response: data.output,
+          createdAt: serverTimestamp()
+        });
+      } catch (err) {
+        console.error('Failed to save prompt history', err);
+      }
+    }
   } catch (err) {
     resultEl.textContent = 'Error generating code';
   }

--- a/docs/js/prompt-history.js
+++ b/docs/js/prompt-history.js
@@ -1,0 +1,64 @@
+import { auth, db } from './firebase.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+import { collection, query, orderBy, limit, getDocs } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+
+const loadingEl = document.getElementById('auth-loading');
+const contentEl = document.getElementById('protected-content');
+const listEl = document.getElementById('history-list');
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user || !user.emailVerified) {
+    window.location.replace('/login/');
+    return;
+  }
+  if (loadingEl) loadingEl.classList.add('hidden');
+  if (contentEl) contentEl.classList.remove('hidden');
+  try {
+    const q = query(
+      collection(db, 'users', user.uid, 'prompts'),
+      orderBy('createdAt', 'desc'),
+      limit(50)
+    );
+    const snap = await getDocs(q);
+    snap.forEach((docSnap) => {
+      const data = docSnap.data();
+      const item = document.createElement('div');
+      item.className = 'border rounded p-4 bg-gray-50';
+
+      const header = document.createElement('div');
+      header.className = 'flex justify-between items-center cursor-pointer';
+
+      const title = document.createElement('div');
+      const text = data.prompt || '';
+      title.textContent = text.length > 100 ? text.slice(0, 100) + '…' : text;
+
+      const meta = document.createElement('div');
+      const modeSpan = document.createElement('span');
+      modeSpan.className = 'text-xs px-2 py-1 rounded bg-gray-200 mr-2';
+      modeSpan.textContent = data.mode || '';
+      const dateSpan = document.createElement('span');
+      const date = data.createdAt?.toDate ? data.createdAt.toDate() : null;
+      dateSpan.className = 'text-xs text-gray-500';
+      dateSpan.textContent = date ? date.toLocaleString() : '';
+      meta.appendChild(modeSpan);
+      meta.appendChild(dateSpan);
+
+      header.appendChild(title);
+      header.appendChild(meta);
+
+      const body = document.createElement('pre');
+      body.className = 'mt-2 whitespace-pre-wrap hidden text-sm bg-white p-2 rounded border';
+      body.textContent = data.response || '';
+
+      header.addEventListener('click', () => {
+        body.classList.toggle('hidden');
+      });
+
+      item.appendChild(header);
+      item.appendChild(body);
+      listEl.appendChild(item);
+    });
+  } catch (err) {
+    console.error('Failed to load prompt history', err);
+  }
+});

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -18,9 +18,11 @@ async function initSidebar() {
 
 function setupAuth() {
   const userDiv = document.getElementById('sidebar-user');
+  const historyItem = document.getElementById('prompt-history-item');
   if (!userDiv) return;
   onAuthStateChanged(auth, (user) => {
     userDiv.textContent = '';
+    if (historyItem) historyItem.classList.add('hidden');
     if (!user) return;
     if (user.photoURL) {
       const img = document.createElement('img');
@@ -33,6 +35,7 @@ function setupAuth() {
     const span = document.createElement('span');
     span.textContent = user.email || '';
     userDiv.appendChild(span);
+    if (historyItem) historyItem.classList.remove('hidden');
   });
 }
 

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prompt History - Devopsia</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
+  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
+  <div id="protected-content" class="hidden">
+    <div class="flex min-h-screen pt-16">
+      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
+      <main class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">Prompt History</h1>
+        <div id="history-list" class="space-y-4"></div>
+      </main>
+    </div>
+  </div>
+  <script type="module" src="/js/firebase.js"></script>
+  <script type="module" src="/js/auth.js"></script>
+  <script type="module" src="/js/prompt-history.js"></script>
+  <script type="module" src="/js/sidebar.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store generated prompts and responses in Firestore
- add prompt history page with auth-required view
- expose prompt history link in sidebar for logged-in users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689491d886d4832fa3b5cc89ebbb9699