### PR TITLE
Unify prompt mode controls across docs

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
@@ -44,6 +46,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
@@ -44,6 +46,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
@@ -44,6 +46,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
@@ -44,6 +46,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
@@ -43,6 +45,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -29,10 +29,12 @@
                 </div>
               </div>
             </div>
-            <div id="prompt-mode-buttons" class="flex gap-2 mb-4">
-              <button data-mode="standard" class="bg-green-500 text-white px-4 py-2 rounded hover:bg-blue-600">Default</button>
-              <button data-mode="optimized" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Optimized</button>
-              <button data-mode="secure" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Secure</button>
+            <div class="mode-toolbar mb-4">
+              <div id="prompt-mode-buttons">
+                <button class="btn-mode" data-mode="default">Default</button>
+                <button class="btn-mode" data-mode="optimized">Optimized</button>
+                <button class="btn-mode" data-mode="secure">Secure</button>
+              </div>
             </div>
           </div>
           <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your YAML question..."></textarea>
@@ -44,6 +46,7 @@
       </main>
     </div>
   </div>
+  <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>

--- a/docs/js/prompt-history.js
+++ b/docs/js/prompt-history.js
@@ -5,7 +5,7 @@ import { collection, query, orderBy, limit, getDocs, doc, updateDoc } from 'http
 const loadingEl = document.getElementById('auth-loading');
 const contentEl = document.getElementById('protected-content');
 const listEl = document.getElementById('history-list');
-const exportJsonBtn = document.getElementById('export-json');
+const exportJsonBtn = document.getElementById('export-json-btn');
 const exportCsvBtn = document.getElementById('export-csv');
 
 onAuthStateChanged(auth, async (user) => {

--- a/docs/js/ui-common.js
+++ b/docs/js/ui-common.js
@@ -1,0 +1,132 @@
+(function() {
+  function safeQuery(sel, root=document) { return root.querySelector(sel); }
+  function safeQueryAll(sel, root=document) { return Array.from(root.querySelectorAll(sel)); }
+
+  // Returns the className of the export button on prompt-history as a string, or a fallback.
+  function getExportBtnClasses() {
+    const src = safeQuery('#export-json-btn');
+    if (src && src.className) return src.className;
+    // Fallback Tailwind style similar to common primary buttons
+    return 'inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md ' +
+           'bg-blue-500 text-white hover:bg-blue-600 transition border border-transparent';
+  }
+
+  // Apply the export button classes to target buttons, and enforce equal sizing.
+  function applyExportStyleToModes(container) {
+    const exportClasses = getExportBtnClasses();
+    const buttons = safeQueryAll('.btn-mode', container);
+    buttons.forEach(btn => {
+      btn.className = `btn-mode ${exportClasses} min-w-[140px]`;
+    });
+    // Positioning: if a parent toolbar/group exists, ensure spacing and wrap like prompt-history
+    const group = container.closest('.mode-toolbar') || container;
+    if (group) {
+      group.classList.add('flex', 'flex-wrap', 'gap-2', 'items-center');
+    }
+  }
+
+  // Visual "active" state based on export btn style (swap to green variant for clarity)
+  function setActiveButton(buttons, activeBtn) {
+    buttons.forEach(b => {
+      b.classList.remove('bg-green-500', 'hover:bg-green-600');
+    });
+    if (activeBtn) {
+      // Replace the base blue with green to indicate active
+      activeBtn.classList.remove('bg-blue-500', 'hover:bg-blue-600');
+      activeBtn.classList.add('bg-green-500', 'hover:bg-green-600');
+      activeBtn.setAttribute('aria-pressed', 'true');
+    }
+  }
+
+  // Initialize prompt mode buttons:
+  // - Delegated click handling
+  // - localStorage persistence
+  // - On load: restore & call window.onModeChange(mode) if defined
+  function initPromptModeControls() {
+    const path = window.location.pathname;
+    const match = path.match(/ai-assistant-([^/]+)/);
+    const assistantKey = match ? match[1] : 'generic';
+    const STORAGE_KEY = `devopsia.promptMode.${assistantKey}`;
+
+    const container = safeQuery('#prompt-mode-buttons');
+    if (!container) return;
+
+    applyExportStyleToModes(container);
+
+    const buttons = safeQueryAll('.btn-mode', container);
+    const availableModes = buttons.map(b => b.dataset.mode).filter(Boolean);
+
+    function highlight(mode) {
+      // Reset to base (blue) for all, then set active (green) for chosen
+      buttons.forEach(b => {
+        b.classList.remove('bg-green-500', 'hover:bg-green-600');
+        if (!b.classList.contains('bg-blue-500')) {
+          b.classList.add('bg-blue-500', 'hover:bg-blue-600');
+        }
+        b.setAttribute('aria-pressed', 'false');
+      });
+      const activeBtn = buttons.find(b => b.dataset.mode === mode);
+      setActiveButton(buttons, activeBtn);
+    }
+
+    const onModeChange = window.onModeChange || function(mode){ console.log('[Devopsia] Mode:', mode); };
+
+    let savedMode = localStorage.getItem(STORAGE_KEY);
+    if (!savedMode || !availableModes.includes(savedMode)) {
+      savedMode = availableModes[0] || 'default';
+    }
+    highlight(savedMode);
+    onModeChange(savedMode);
+
+    // Delegated events support dynamic DOM
+    container.addEventListener('click', (e) => {
+      const btn = e.target.closest('.btn-mode');
+      if (!btn || !container.contains(btn)) return;
+
+      const mode = btn.dataset.mode;
+      if (!mode) return;
+
+      localStorage.setItem(STORAGE_KEY, mode);
+      highlight(mode);
+      onModeChange(mode);
+    });
+  }
+
+  // Fix incorrect Terraform link in the sidebar and normalize other assistant links
+  function fixSidebarAssistantLinks() {
+    const map = {
+      'terraform': '/ai-assistant-terraform/',
+      'helm': '/ai-assistant-helm/',
+      'k8s': '/ai-assistant-k8s/',
+      'yaml': '/ai-assistant-yaml/',
+      'ansible': '/ai-assistant-ansible/',
+      'docker': '/ai-assistant-docker/'
+    };
+
+    const sidebar = safeQuery('#sidebar-container') || document;
+    Object.entries(map).forEach(([key, url]) => {
+      // Try data attribute first
+      const link = safeQuery(`a[data-assistant="${key}"]`, sidebar)
+                || safeQuery(`a[href*="ai-assist"][href*="${key}"]`, sidebar)
+                || safeQuery(`a[href*="${key}"]`, sidebar);
+      if (link) link.setAttribute('href', url);
+    });
+
+    // Explicitly fix the typo if still present
+    const bad = safeQuery('a[href="/ai-assistnat"]', sidebar);
+    if (bad) bad.setAttribute('href', '/ai-assistant-terraform/');
+  }
+
+  // Public init
+  window.DevopsiaUI = {
+    initPromptModeControls,
+    fixSidebarAssistantLinks,
+    applyExportStyleToModes,
+    getExportBtnClasses
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    fixSidebarAssistantLinks();
+    initPromptModeControls();
+  });
+})();

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -24,7 +24,7 @@
             ⭐ Save to Favorites
           </button>
           <div class="flex gap-2">
-            <button id="export-json" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
+            <button id="export-json-btn" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
               Export JSON
             </button>
             <button id="export-csv" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,138 @@
       "dependencies": {
         "node-fetch": "^3.3.2",
         "stripe": "^12.18.0"
+      },
+      "devDependencies": {
+        "jsdom": "^26.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -19,6 +151,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -50,6 +192,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -58,6 +214,45 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -71,6 +266,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -220,6 +428,114 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -228,6 +544,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -267,6 +590,13 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
+      "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -277,6 +607,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -292,6 +645,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/side-channel": {
@@ -379,11 +759,77 @@
         "node": ">=12.*"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -393,6 +839,92 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "test": "echo \"No tests defined\" && exit 0"
+    "test": "node --test"
   },
   "dependencies": {
-    "stripe": "^12.18.0",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "stripe": "^12.18.0"
+  },
+  "devDependencies": {
+    "jsdom": "^26.1.0"
   }
 }

--- a/tests/ai-assistant-ui.test.js
+++ b/tests/ai-assistant-ui.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {JSDOM} from 'jsdom';
+import fs from 'fs';
+import vm from 'vm';
+
+// helper to load ui-common.js into a window
+function loadUiCommon(window){
+  const code = fs.readFileSync('./docs/js/ui-common.js', 'utf8');
+  const context = vm.createContext({ window, document: window.document, localStorage: window.localStorage, console });
+  const script = new vm.Script(code, { filename: 'ui-common.js' });
+  script.runInContext(context);
+  return context.window.DevopsiaUI;
+}
+
+// helper to load ai-assistant.js with stubbed firebase
+function loadAiAssistant(window, {plan='free'} = {}){
+  const raw = fs.readFileSync('./docs/js/ai-assistant.js', 'utf8');
+    const sanitized = raw
+      .replace(/import[^;]+;\n/g, '')
+      .replace('export function promptComponent', 'function promptComponent')
+      .replace('setTimeout(() => toast.remove(), 3000);', '');
+    const code = sanitized + '\nwindow.__getCurrentMode = () => currentMode;\n';
+    const context = vm.createContext({ window, document: window.document, localStorage: window.localStorage, console });
+  // stub firebase and firestore helpers
+  context.auth = {};
+  context.db = {};
+  context.onAuthStateChanged = (auth, cb) => cb({ uid: 'u', emailVerified: true });
+  context.doc = () => ({});
+  context.getDoc = async () => ({ exists: () => true, data: () => ({ plan }) });
+  context.setDoc = async () => {};
+  context.collection = () => ({});
+  context.addDoc = async () => {};
+  context.serverTimestamp = () => 0;
+  const script = new vm.Script(code, { filename: 'ai-assistant.js' });
+  script.runInContext(context);
+  return { promptComponent: context.promptComponent, context };
+}
+
+function createDom(path, {withExport=true} = {}){
+  const exportBtn = withExport ? '<button id="export-json-btn" class="inline-flex px-4 py-2 bg-blue-500 text-white hover:bg-blue-600">Export JSON</button>' : '';
+  const html = `${exportBtn}<div class="mode-toolbar mb-4"><div id="prompt-mode-buttons"><button class="btn-mode" data-mode="default">Default</button><button class="btn-mode" data-mode="optimized">Optimized</button><button class="btn-mode" data-mode="secure">Secure</button></div></div><button id="runPrompt"></button><div id="result"></div>`;
+  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url: `https://example.com/${path}/`});
+  return dom;
+}
+
+const assistants = ['terraform','helm','k8s','yaml','ansible','docker'];
+
+test('prompt mode persists across reloads for each assistant page', () => {
+  for (const key of assistants){
+    const dom1 = createDom(`ai-assistant-${key}`, {withExport:false});
+    const {window} = dom1;
+    const ui = loadUiCommon(window);
+    ui.initPromptModeControls();
+    const optBtn = window.document.querySelector('.btn-mode[data-mode="optimized"]');
+    optBtn.click();
+    const storageKey = `devopsia.promptMode.${key}`;
+    const saved = window.localStorage.getItem(storageKey);
+    // simulate reload
+    const dom2 = createDom(`ai-assistant-${key}`, {withExport:false});
+    dom2.window.localStorage.setItem(storageKey, saved);
+    const ui2 = loadUiCommon(dom2.window);
+    ui2.initPromptModeControls();
+    const active = dom2.window.document.querySelector('.btn-mode.bg-green-500');
+    assert.ok(active, 'active button should be highlighted');
+    assert.equal(active.dataset.mode, 'optimized');
+  }
+});
+
+test('secure button disabled for non-pro users', async () => {
+  const dom = createDom('ai-assistant-terraform');
+  const {window} = dom;
+  const ui = loadUiCommon(window);
+  ui.initPromptModeControls();
+  const {promptComponent} = loadAiAssistant(window, {plan:'free'});
+  const comp = promptComponent();
+  await comp.init();
+  const secureBtn = window.document.querySelector('.btn-mode[data-mode="secure"]');
+  assert.ok(secureBtn.disabled);
+  assert.ok(secureBtn.classList.contains('opacity-50'));
+});
+
+test('non-Pro users cannot activate secure mode and receive toast', async () => {
+  const dom = createDom('ai-assistant-terraform');
+  const {window} = dom;
+  const ui = loadUiCommon(window);
+  ui.initPromptModeControls();
+  const {promptComponent, context} = loadAiAssistant(window, {plan:'free'});
+  const comp = promptComponent();
+  await comp.init();
+  // attempt to activate secure mode programmatically within VM context
+  vm.runInContext('window.onModeChange("secure")', context);
+  const toast = Array.from(window.document.querySelectorAll('div')).find(d => d.textContent.includes('Secure mode is available on Pro only'));
+  assert.ok(toast, 'toast should appear');
+  assert.equal(window.__getCurrentMode(), 'default');
+});
+
+test('mode buttons adopt export button styles', () => {
+  const dom = createDom('ai-assistant-terraform');
+  const {window} = dom;
+  const ui = loadUiCommon(window);
+  ui.initPromptModeControls();
+  const exportClass = window.document.getElementById('export-json-btn').className;
+  const exportClasses = exportClass.split(/\s+/).filter(Boolean);
+  const buttons = window.document.querySelectorAll('#prompt-mode-buttons .btn-mode');
+  buttons.forEach(btn => {
+    assert.equal(btn.classList.contains('btn-mode'), true);
+    assert.equal(btn.classList.contains('min-w-[140px]'), true);
+    exportClasses.forEach(cls => {
+      if (cls.startsWith('bg-') || cls.startsWith('hover:bg-')) return;
+      assert.equal(btn.classList.contains(cls), true);
+    });
+  });
+  // non-active buttons should retain base blue styles
+  ['optimized','secure'].forEach(mode => {
+    const btn = window.document.querySelector(`.btn-mode[data-mode="${mode}"]`);
+    ['bg-blue-500','hover:bg-blue-600'].forEach(cls => assert.equal(btn.classList.contains(cls), true));
+  });
+  const group = window.document.querySelector('.mode-toolbar');
+  ['flex','flex-wrap','gap-2','items-center'].forEach(cls => assert.equal(group.classList.contains(cls), true));
+});


### PR DESCRIPTION
## Summary
- add id for export button on prompt history
- introduce shared ui helpers for mode buttons and sidebar link fixes
- align all AI assistant pages to use common prompt mode controls
- add jsdom-based tests for mode persistence, secure restrictions, and styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d5e65f50832f890f92476fd98876