### PR TITLE
feat(auth): guard /ai-assistant/* and enforce email verification

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -48,7 +68,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -48,7 +68,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -48,7 +68,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -48,7 +68,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -47,7 +67,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -9,6 +9,26 @@
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <style>
+    html.auth-checking body { visibility: hidden; }
+  </style>
+  <script>
+    document.documentElement.classList.add('auth-checking');
+    firebase.auth().onAuthStateChanged(() => {
+      document.documentElement.classList.remove('auth-checking');
+    });
+  </script>
+  <script type="module">
+    import { requireAuth } from '/js/auth.js';
+    // Block page until auth is validated; unverified users are redirected to /verify-email
+    requireAuth({ mustBeVerified: true }).catch(() => {});
+  </script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
@@ -48,7 +68,6 @@
   </div>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
   <script type="module" src="/js/sidebar.js"></script>
   <script type="module" src="/js/header.js"></script>

--- a/docs/behind-the-build/index.html
+++ b/docs/behind-the-build/index.html
@@ -18,7 +18,7 @@
         <a href="/#features" class="hover:underline">Features</a>
         <a href="/pricing/" class="hover:underline">Pricing</a>
         <a href="/behind-the-build/" class="hover:underline">Behind the Build</a>
-        <a href="/pricing/" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Let’s Build</a>
+        <a id="cta-build-btn" href="/pricing/" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Let’s Build</a>
         <a id="authButton" href="/login/" class="hover:underline">Login</a>
       </nav>
       <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
@@ -74,5 +74,19 @@
   <footer class="text-center py-4">© 2025 Devopsia</footer>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script type="module">
+    import { auth } from '/js/firebase.js';
+    const next = encodeURIComponent('/ai-assistant/');
+    function handleStartBuilding(e) {
+      e.preventDefault();
+      const user = auth.currentUser;
+      if (user && user.emailVerified) {
+        window.location.href = '/ai-assistant/';
+      } else {
+        window.location.href = `/login/?next=${next}`;
+      }
+    }
+    document.getElementById('cta-build-btn')?.addEventListener('click', handleStartBuilding);
+  </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,22 +106,30 @@
     const auth = getAuth(app);
 
     function handleStartBuilding() {
-      const user = auth.currentUser || (window.firebase && window.firebase.auth && window.firebase.auth().currentUser);
-      window.location.href = user ? '/pricing/' : '/login/';
+      const next = encodeURIComponent('/ai-assistant/');
+      const user = auth.currentUser;
+      if (user && user.emailVerified) {
+        window.location.href = '/ai-assistant/';
+      } else {
+        window.location.href = `/login/?next=${next}`;
+      }
     }
 
     onAuthStateChanged(auth, user => {
-      const ctaBtn = document.getElementById('cta-build-btn');
       const homeBtn = document.getElementById('home-logo-btn');
-      if (ctaBtn) {
-        ctaBtn.setAttribute('href', user ? '/ai-assistant-terraform/' : '/pricing/');
-      }
       if (homeBtn) {
-        homeBtn.setAttribute('href', user ? '/ai-assistant-terraform/' : '/');
+        homeBtn.setAttribute('href', user && user.emailVerified ? '/ai-assistant/' : '/');
       }
     });
 
     document.addEventListener('DOMContentLoaded', () => {
+      const ctaBtn = document.getElementById('cta-build-btn');
+      if (ctaBtn) {
+        ctaBtn.addEventListener('click', e => {
+          e.preventDefault();
+          handleStartBuilding();
+        });
+      }
       const buttons = Array.from(document.querySelectorAll('button, a')).filter(el =>
         el.classList.contains('start-button') || el.textContent.trim() === 'Start Building'
       );

--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -1,29 +1,61 @@
-import { auth } from './firebase.js';
-import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
+// /docs/js/auth.js
+// Shared Firebase Auth helpers for Devopsia (GitHub Pages)
+// Assumes firebase-app.js and firebase-auth.js are loaded globally on pages that use this.
+// Exports:
+// - requireAuth({ mustBeVerified: true, redirectIfAuthedTo })
+// - getCurrentUserOnce()
+// - sendVerificationEmail(user)
 
-function updateAuthButton(user) {
-  const btn = document.getElementById('authButton');
-  if (!btn) return;
-  btn.onclick = null;
-  if (user) {
-    btn.textContent = 'Logout';
-    btn.href = '#';
-    btn.addEventListener('click', async (e) => {
-      e.preventDefault();
-      await signOut(auth);
-      window.location.href = '/';
-    }, { once: true });
-  } else {
-    btn.textContent = 'Login';
-    btn.href = '/login/';
+export async function getCurrentUserOnce() {
+  return new Promise((resolve) => {
+    const unsub = firebase.auth().onAuthStateChanged((u) => {
+      unsub();
+      resolve(u || null);
+    });
+  });
+}
+
+export async function requireAuth({ mustBeVerified = true } = {}) {
+  const user = await getCurrentUserOnce();
+  // If no user, bounce to login with ?next=<current-url>
+  if (!user) {
+    const next = encodeURIComponent(window.location.pathname + window.location.search);
+    window.location.href = `/login/?next=${next}`;
+    return Promise.reject(new Error('Unauthenticated'));
+  }
+  // If must be verified, enforce emailVerified
+  if (mustBeVerified && !user.emailVerified) {
+    // Sign out to avoid partial session usage, then route to verify page
+    await firebase.auth().signOut();
+    const next = encodeURIComponent(window.location.pathname + window.location.search);
+    window.location.href = `/verify-email/?next=${next}`;
+    return Promise.reject(new Error('Email not verified'));
+  }
+  return user;
+}
+
+export async function sendVerificationEmail(user) {
+  try {
+    await user.sendEmailVerification({
+      // Optional: customize with dynamic link domain if configured in Firebase Auth
+      // url: `${location.origin}/verify-email/`,
+      handleCodeInApp: false,
+    });
+    return true;
+  } catch (err) {
+    console.error('sendVerificationEmail failed', err);
+    return false;
   }
 }
 
-document.addEventListener('header-loaded', () => {
-  updateAuthButton(auth.currentUser);
-});
+// Helper: handle “next” param after successful login
+export function redirectPostLogin() {
+  const params = new URLSearchParams(window.location.search);
+  const next = params.get('next');
+  if (next) {
+    window.location.replace(next);
+  } else {
+    window.location.replace('/ai-assistant/');
+  }
+}
 
-document.addEventListener('DOMContentLoaded', () => {
-  updateAuthButton(auth.currentUser);
-  onAuthStateChanged(auth, updateAuthButton);
-});

--- a/docs/js/firebase-config.js
+++ b/docs/js/firebase-config.js
@@ -1,0 +1,11 @@
+// Global Firebase configuration for client-side usage
+window.firebaseConfig = {
+  apiKey: "AIzaSyA0bTCMkxBeZ9RQsqWSBI92-M6fcnwGbOU",
+  authDomain: "devopsia-39ea5.firebaseapp.com",
+  projectId: "devopsia-39ea5",
+  storageBucket: "devopsia-39ea5.firebasestorage.app",
+  messagingSenderId: "789816052410",
+  appId: "1:789816052410:web:241ea4bd6a5b60ba855083",
+  measurementId: "G-V190R34CQD"
+};
+

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -49,9 +49,9 @@
     <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
       <h1 class="text-3xl font-extrabold mb-6 text-center">Sign In to Devopsia</h1>
       <form id="login-form" class="space-y-4">
-        <input type="email" id="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <input type="password" id="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <p id="loginError" class="text-red-600 hidden"></p>
+        <input type="email" id="email" name="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <input type="password" id="password" name="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <p id="login-error" class="text-red-600"></p>
         <button id="loginBtn" type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Login</button>
       </form>
       <button id="google-login" class="mt-4 w-full flex items-center justify-center gap-2 border border-gray-300 rounded py-2 bg-white hover:bg-gray-50">
@@ -65,8 +65,39 @@
     </div>
   </main>
   <footer class="text-center py-4">© 2025 Devopsia</footer>
-  <script type="module" src="/js/login.js"></script>
-  <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/auth.js"></script>
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <script type="module">
+    import { redirectPostLogin } from '/js/auth.js';
+    const form = document.getElementById('login-form');
+    const errorEl = document.getElementById('login-error');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.textContent = '';
+      const email = form.email.value.trim();
+      const password = form.password.value;
+      try {
+        const cred = await firebase.auth().signInWithEmailAndPassword(email, password);
+        const user = cred.user;
+        // Enforce verification
+        if (!user.emailVerified) {
+          await firebase.auth().signOut();
+          const params = new URLSearchParams(window.location.search);
+          const next = params.get('next') || '/ai-assistant/';
+          window.location.href = `/verify-email/?next=${encodeURIComponent(next)}&notice=unverified`;
+          return;
+        }
+        // Verified → proceed
+        redirectPostLogin();
+      } catch (err) {
+        console.error(err);
+        errorEl.textContent = 'Login failed. Please check your credentials.';
+      }
+    });
+  </script>
 </body>
 </html>

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -15,8 +15,6 @@
       max-width: none;
     }
   </style>
-  <script type="module" src="/js/firebase.js"></script>
-  <script type="module" src="/js/signup.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
   <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
@@ -49,10 +47,10 @@
   <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
     <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
       <h1 class="text-3xl font-extrabold mb-6 text-center">Create your account</h1>
-      <form id="signupForm" class="space-y-4">
+      <form id="signup-form" class="space-y-4">
         <input type="text" id="fullName" placeholder="Full Name" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <input type="email" id="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <input type="password" id="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <input type="email" id="email" name="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
+        <input type="password" id="password" name="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
         <input type="password" id="confirmPassword" placeholder="Confirm Password" required class="w-full border border-gray-300 rounded px-4 py-2">
         <select id="plan" class="w-full border border-gray-300 rounded px-4 py-2">
           <option value="free">Free</option>
@@ -144,14 +142,44 @@
         </label>
 
         <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Create Account</button>
-        <p id="signupError" class="text-red-500 text-sm hidden"></p>
+        <p id="signup-error" class="text-red-500 text-sm"></p>
+        <p id="signup-success" class="text-green-600 text-sm"></p>
       </form>
       <p class="mt-4 text-center text-sm">Already have an account? <a href="/login/" class="text-orange-600 hover:underline">Log in</a></p>
     </div>
   </main>
   <footer class="text-center py-4">© 2025 Devopsia</footer>
 
-  <script type="module" src="/js/auth.js"></script>
-
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+  <script type="module">
+    import { sendVerificationEmail } from '/js/auth.js';
+    const form = document.getElementById('signup-form');
+    const errorEl = document.getElementById('signup-error');
+    const successEl = document.getElementById('signup-success');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.textContent = '';
+      successEl.textContent = '';
+      const email = form.email.value.trim();
+      const password = form.password.value;
+      try {
+        const cred = await firebase.auth().createUserWithEmailAndPassword(email, password);
+        const user = cred.user;
+        await sendVerificationEmail(user);
+        await firebase.auth().signOut();
+        const params = new URLSearchParams(window.location.search);
+        const next = params.get('next') || '/ai-assistant/';
+        window.location.href = `/verify-email/?next=${encodeURIComponent(next)}&notice=sent`;
+      } catch (err) {
+        console.error(err);
+        errorEl.textContent = 'Signup failed. Please try again.';
+      }
+    });
+  </script>
 </body>
 </html>

--- a/docs/verify-email/index.html
+++ b/docs/verify-email/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Verify your email — Devopsia</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="/css/style.css" rel="stylesheet" />
+  <script src="/js/firebase-config.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth.js"></script>
+  <script>
+    if (!firebase.apps.length) firebase.initializeApp(window.firebaseConfig);
+  </script>
+</head>
+<body class="min-h-screen flex items-center justify-center bg-gray-50 text-gray-700">
+  <div class="max-w-md w-full bg-white shadow rounded-2xl p-6 space-y-4">
+    <h1 class="text-xl font-semibold">Check your email</h1>
+    <p id="notice" class="text-sm text-gray-600"></p>
+    <div class="space-y-3">
+      <button id="resend" class="w-full bg-gray-900 text-white py-2 rounded-lg">Resend verification email</button>
+      <button id="go-login" class="w-full bg-gray-100 py-2 rounded-lg">Back to Login</button>
+    </div>
+  </div>
+  <script type="module">
+    import { getCurrentUserOnce, sendVerificationEmail } from '/js/auth.js';
+    const params = new URLSearchParams(window.location.search);
+    const next = params.get('next') || '/ai-assistant/';
+    const noticeParam = params.get('notice');
+    const noticeEl = document.getElementById('notice');
+    if (noticeParam === 'sent') {
+      noticeEl.textContent = 'We sent a verification email. Please click the link in your inbox.';
+    } else if (noticeParam === 'unverified') {
+      noticeEl.textContent = 'Your email is not verified. Please verify to continue.';
+    } else {
+      noticeEl.textContent = 'Please verify your email to continue.';
+    }
+    document.getElementById('go-login').addEventListener('click', () => {
+      window.location.href = `/login/?next=${encodeURIComponent(next)}`;
+    });
+    document.getElementById('resend').addEventListener('click', async () => {
+      const user = await getCurrentUserOnce();
+      if (user && !user.emailVerified) {
+        const ok = await sendVerificationEmail(user);
+        noticeEl.textContent = ok
+          ? 'Verification email re-sent. Please check your inbox.'
+          : 'Failed to resend. Please try again later.';
+      } else {
+        noticeEl.textContent = 'Please login first to resend the verification email.';
+        setTimeout(() => {
+          window.location.href = `/login/?next=${encodeURIComponent(next)}`;
+        }, 1200);
+      }
+    });
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add reusable Firebase auth helpers
- guard all AI assistant pages and require verified accounts
- enforce verification in login and signup flows with new verify-email page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47e4d4680832f932dfb4c63a0e8a5