### PR TITLE
feat: redesign sidebar with sticky accordion

### DIFF
--- a/docs/ai-assistant/ansible/index.html
+++ b/docs/ai-assistant/ansible/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI Assistant for K8s</title>
+  <title>AI Assistant for Ansible</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -14,10 +14,10 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for K8s</h1>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Ansible</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
             <div class="flex items-center mb-1">
@@ -37,8 +37,8 @@
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
-          <input type="hidden" id="tool" value="k8s">
+          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
+          <input type="hidden" id="tool" value="ansible">
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
@@ -46,11 +46,26 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
+

--- a/docs/ai-assistant/docker/index.html
+++ b/docs/ai-assistant/docker/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI Assistant - Devopsia</title>
+  <title>AI Assistant for Docker</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -14,10 +14,10 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Terraform</h1>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Docker</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
             <div class="flex items-center mb-1">
@@ -37,7 +37,8 @@
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
+          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
+          <input type="hidden" id="tool" value="docker">
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
@@ -45,12 +46,26 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/docs/ai-assistant/helm/index.html
+++ b/docs/ai-assistant/helm/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI Assistant for Ansible</title>
+  <title>AI Assistant for Helm</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -14,10 +14,10 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Ansible</h1>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Helm</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
             <div class="flex items-center mb-1">
@@ -37,8 +37,8 @@
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
-          <input type="hidden" id="tool" value="ansible">
+          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
+          <input type="hidden" id="tool" value="helm">
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
@@ -46,12 +46,26 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/docs/ai-assistant/k8s/index.html
+++ b/docs/ai-assistant/k8s/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI Assistant for Helm</title>
+  <title>AI Assistant for K8s</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -14,10 +14,10 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Helm</h1>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">AI Assistant for K8s</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
             <div class="flex items-center mb-1">
@@ -37,8 +37,8 @@
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
-          <input type="hidden" id="tool" value="helm">
+          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
+          <input type="hidden" id="tool" value="k8s">
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
@@ -46,12 +46,25 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
-

--- a/docs/ai-assistant/terraform/index.html
+++ b/docs/ai-assistant/terraform/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI Assistant for Docker</title>
+  <title>AI Assistant - Devopsia</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -14,10 +14,10 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Docker</h1>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
+        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Terraform</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
             <div class="flex items-center mb-1">
@@ -37,8 +37,7 @@
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
-          <input type="hidden" id="tool" value="docker">
+          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
@@ -46,12 +45,26 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/docs/ai-assistant/yaml/index.html
+++ b/docs/ai-assistant/yaml/index.html
@@ -14,9 +14,9 @@
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
     <div id="header-container"></div>
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for YAML</h1>
         <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
           <div>
@@ -46,12 +46,26 @@
       </main>
     </div>
   </div>
+
+
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
-  <script type="module" src="/js/header.js"></script>
+    <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>
 

--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -1,18 +1,43 @@
-<aside class="w-64 min-h-screen bg-gray-100 p-4 flex flex-col justify-between">
-  <div>
-    <div id="sidebar-user" class="mb-4 text-sm text-gray-600"></div>
-    <h2 class="font-bold mb-3 text-lg">AI Assistants</h2>
-    <ul class="space-y-2">
-      <li><a href="/ai-assistant-terraform/" class="block px-2 py-1 rounded hover:bg-gray-200">Terraform</a></li>
-      <li><a href="/ai-assistant-helm/" class="block px-2 py-1 rounded hover:bg-gray-200">Helm</a></li>
-      <li><a href="/ai-assistant-k8s/" class="block px-2 py-1 rounded hover:bg-gray-200">K8s</a></li>
-      <li><a href="/ai-assistant-yaml/" class="block px-2 py-1 rounded hover:bg-gray-200">YAML</a></li>
-      <li><a href="/ai-assistant-ansible/" class="block px-2 py-1 rounded hover:bg-gray-200">Ansible</a></li>
-      <li><a href="/ai-assistant-docker/" class="block px-2 py-1 rounded hover:bg-gray-200">Docker</a></li>
-      <li id="prompt-history-item" class="hidden"><a href="/prompt-history/" class="block px-2 py-1 rounded hover:bg-gray-200">Prompt History</a></li>
-    </ul>
+<nav id="app-sidebar" class="w-full lg:w-64 bg-white border-r border-gray-200 h-full">
+  <div class="p-4">
+    <!-- Top: Home -->
+    <a href="/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100" data-link="home">
+      <span>Home</span>
+    </a>
+
+    <!-- AI Assistants accordion -->
+    <details id="ai-assistants-accordion" class="mt-2 group" open>
+      <summary class="sidebar-link flex items-center justify-between px-3 py-2 rounded cursor-pointer hover:bg-gray-100">
+        <span>AI Assistants</span>
+        <svg class="w-4 h-4 transition-transform group-open:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.17l3.71-2.94a.75.75 0 111.04 1.08l-4.24 3.36a.75.75 0 01-.94 0L5.21 8.31a.75.75 0 01.02-1.1z" clip-rule="evenodd"/>
+        </svg>
+      </summary>
+      <div class="ml-2 mt-1 space-y-1">
+        <a href="/ai-assistant/terraform/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="terraform">Terraform</a>
+        <a href="/ai-assistant/helm/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="helm">Helm</a>
+        <a href="/ai-assistant/k8s/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="k8s">K8s</a>
+        <a href="/ai-assistant/ansible/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="ansible">Ansible</a>
+        <a href="/ai-assistant/yaml/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="yaml">YAML</a>
+        <a href="/ai-assistant/docker/" class="sidebar-sublink block px-4 py-2 rounded hover:bg-gray-100" data-link="docker">Docker</a>
+      </div>
+    </details>
+
+    <!-- Profile -->
+    <a href="/profile/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-2" data-link="profile">
+      <span>Profile</span>
+    </a>
+
+    <!-- Prompt History -->
+    <a href="/prompt-history/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1" data-link="prompt-history">
+      <span>Prompt History</span>
+    </a>
   </div>
-  <button id="logout-btn" class="mt-6 bg-red-100 hover:bg-red-200 text-red-600 px-4 py-2 rounded w-full">
-    Logout
-  </button>
-</aside>
+
+  <!-- Bottom: Sign Out -->
+  <div class="mt-auto p-4 border-t border-gray-200">
+    <button id="sidebar-signout" type="button" class="w-full text-left px-3 py-2 rounded bg-gray-50 hover:bg-gray-100">
+      Sign Out
+    </button>
+  </div>
+</nav>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -230,3 +230,23 @@ a {
   font-weight: bold;
   margin: 0.5rem 0 1rem 0;
 }
+
+/* Sidebar layout helpers */
+#app-sidebar { display: flex; flex-direction: column; }
+
+/* Ensure the page layout uses a two-column grid on large screens */
+@media (min-width: 1024px) {
+  .with-sidebar {
+    display: grid;
+    grid-template-columns: 16rem 1fr;
+    gap: 1.25rem;
+    align-items: start;
+  }
+}
+
+/* Prevent header overlap if header is fixed ~64px */
+.lg\:top-16 { top: 4rem; }
+
+/* details/summary pointer + reset default marker */
+details > summary { list-style: none; }
+details > summary::-webkit-details-marker { display: none; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,10 +114,10 @@
       const ctaBtn = document.getElementById('cta-build-btn');
       const homeBtn = document.getElementById('home-logo-btn');
       if (ctaBtn) {
-        ctaBtn.setAttribute('href', user ? '/ai-assistant-terraform/' : '/pricing/');
+        ctaBtn.setAttribute('href', user ? '/ai-assistant/terraform/' : '/pricing/');
       }
       if (homeBtn) {
-        homeBtn.setAttribute('href', user ? '/ai-assistant-terraform/' : '/');
+        homeBtn.setAttribute('href', user ? '/ai-assistant/terraform/' : '/');
       }
     });
 

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -31,7 +31,7 @@ onAuthStateChanged(auth, (user) => {
 
 document.addEventListener('DOMContentLoaded', () => {
   const path = window.location.pathname;
-  const match = path.match(/ai-assistant-([^/]+)/);
+  const match = path.match(/ai-assistant(?:-|\/)([^/]+)/);
   if (match) {
     const name = match[1]
       .replace(/-/g, ' ')

--- a/docs/js/firebase.js
+++ b/docs/js/firebase.js
@@ -15,3 +15,8 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+
+if (typeof window !== 'undefined') {
+  window.firebase = window.firebase || {};
+  window.firebase.auth = () => auth;
+}

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -1,61 +1,54 @@
-import { auth } from './firebase.js';
-import { onAuthStateChanged, signOut } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
-
-async function initSidebar() {
-  const container = document.getElementById('sidebar-container');
-  if (!container) return;
-  try {
-    const res = await fetch('/components/sidebar.html');
-    if (!res.ok) throw new Error('Failed to load sidebar');
-    container.innerHTML = await res.text();
-    setupAuth();
-    highlightLink();
-    setupLogout();
-  } catch (err) {
-    console.error('Sidebar load error', err);
+// Requires Firebase Auth already initialized
+(function () {
+  const signOutBtn = document.getElementById('sidebar-signout');
+  if (signOutBtn && window.firebase?.auth) {
+    signOutBtn.addEventListener('click', async () => {
+      try {
+        await firebase.auth().signOut();
+        window.location.href = '/';
+      } catch (e) {
+        console.error('Sign out failed:', e);
+        alert('Sign out failed. See console for details.');
+      }
+    });
   }
-}
 
-function setupAuth() {
-  const userDiv = document.getElementById('sidebar-user');
-  const historyItem = document.getElementById('prompt-history-item');
-  if (!userDiv) return;
-  onAuthStateChanged(auth, (user) => {
-    userDiv.textContent = '';
-    if (historyItem) historyItem.classList.add('hidden');
-    if (!user) return;
-    if (user.photoURL) {
-      const img = document.createElement('img');
-      img.src = user.photoURL;
-      img.alt = 'User Avatar';
-      img.referrerPolicy = 'no-referrer';
-      img.className = 'w-8 h-8 rounded-full';
-      userDiv.appendChild(img);
+  // Active link highlight based on path
+  const path = window.location.pathname.replace(/\/+$/, '/').toLowerCase();
+
+  function markActive(selector) {
+    document.querySelectorAll(selector).forEach((el) => {
+      el.classList.remove('bg-gray-100', 'text-gray-900', 'font-semibold');
+    });
+    return function (el) {
+      el.classList.add('bg-gray-100', 'text-gray-900', 'font-semibold');
+    };
+  }
+
+  const setActive = markActive('.sidebar-link, .sidebar-sublink');
+
+  // Map routes to data-link keys
+  const routeMap = [
+    { match: /^\/$/, key: 'home' },
+    { match: /^\/ai-assistant\/terraform\/?$/i, key: 'terraform', openAI: true },
+    { match: /^\/ai-assistant\/helm\/?$/i, key: 'helm', openAI: true },
+    { match: /^\/ai-assistant\/k8s\/?$/i, key: 'k8s', openAI: true },
+    { match: /^\/ai-assistant\/ansible\/?$/i, key: 'ansible', openAI: true },
+    { match: /^\/ai-assistant\/yaml\/?$/i, key: 'yaml', openAI: true },
+    { match: /^\/ai-assistant\/docker\/?$/i, key: 'docker', openAI: true },
+    { match: /^\/profile\/?$/i, key: 'profile' },
+    { match: /^\/prompt-history\/?$/i, key: 'prompt-history' },
+  ];
+
+  const hit = routeMap.find(r => r.match.test(path));
+  if (hit) {
+    const target = document.querySelector(`[data-link="${hit.key}"]`);
+    if (target) setActive(target);
+
+    // Ensure AI Assistants accordion opens if a child route is active
+    if (hit.openAI) {
+      const acc = document.getElementById('ai-assistants-accordion');
+      if (acc && !acc.open) acc.open = true;
     }
-    const span = document.createElement('span');
-    span.textContent = user.email || '';
-    userDiv.appendChild(span);
-    if (historyItem) historyItem.classList.remove('hidden');
-  });
-}
-
-function highlightLink() {
-  const path = window.location.pathname;
-  document.querySelectorAll('#sidebar-container a').forEach((link) => {
-    if (link.getAttribute('href') === path) {
-      link.classList.add('bg-gray-200', 'font-semibold');
-    }
-  });
-}
-
-function setupLogout() {
-  const btn = document.getElementById('logout-btn');
-  if (!btn) return;
-  btn.addEventListener('click', async (e) => {
-    e.preventDefault();
-    await signOut(auth);
-    window.location.href = '/';
-  }, { once: true });
-}
-
-document.addEventListener('DOMContentLoaded', initSidebar);
+  }
+})();

--- a/docs/js/ui-common.js
+++ b/docs/js/ui-common.js
@@ -44,7 +44,7 @@
   // - On load: restore & call window.onModeChange(mode) if defined
   function initPromptModeControls() {
     const path = window.location.pathname;
-    const match = path.match(/ai-assistant-([^/]+)/);
+    const match = path.match(/ai-assistant(?:-|\/)([^/]+)/);
     const assistantKey = match ? match[1] : 'generic';
     const STORAGE_KEY = `devopsia.promptMode.${assistantKey}`;
 
@@ -95,12 +95,12 @@
   // Fix incorrect Terraform link in the sidebar and normalize other assistant links
   function fixSidebarAssistantLinks() {
     const map = {
-      'terraform': '/ai-assistant-terraform/',
-      'helm': '/ai-assistant-helm/',
-      'k8s': '/ai-assistant-k8s/',
-      'yaml': '/ai-assistant-yaml/',
-      'ansible': '/ai-assistant-ansible/',
-      'docker': '/ai-assistant-docker/'
+      'terraform': '/ai-assistant/terraform/',
+      'helm': '/ai-assistant/helm/',
+      'k8s': '/ai-assistant/k8s/',
+      'yaml': '/ai-assistant/yaml/',
+      'ansible': '/ai-assistant/ansible/',
+      'docker': '/ai-assistant/docker/'
     };
 
     const sidebar = safeQuery('#sidebar-container') || document;
@@ -114,7 +114,7 @@
 
     // Explicitly fix the typo if still present
     const bad = safeQuery('a[href="/ai-assistnat"]', sidebar);
-    if (bad) bad.setAttribute('href', '/ai-assistant-terraform/');
+    if (bad) bad.setAttribute('href', '/ai-assistant/terraform/');
   }
 
   // Public init

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -13,9 +13,10 @@
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div class="flex min-h-screen pt-16">
-      <div id="sidebar-container" class="w-64 shrink-0 hidden md:block"></div>
-      <main class="flex-1 p-6 bg-white">
+    <div id="header-container"></div>
+    <div class="with-sidebar px-4 lg:px-6 pt-16">
+      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
+      <main id="main-content" class="flex-1 p-6 bg-white">
         <nav class="text-sm text-gray-500 mb-2"><a href="/">Home</a> / Prompt History</nav>
         <h1 class="text-2xl font-semibold mb-4">Prompt History</h1>
         <!-- Action buttons: Save to Favorites and export options -->
@@ -36,9 +37,23 @@
       </main>
     </div>
   </div>
+
+  
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/prompt-history.js"></script>
-  <script type="module" src="/js/sidebar.js"></script>
+  <script type="module" src="/js/header.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const container = document.getElementById('sidebar-container');
+    if (!container) return;
+    const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
+    container.innerHTML = await res.text();
+    // After injecting HTML, load JS
+    const s = document.createElement('script');
+    s.src = '/js/sidebar.js';
+    document.body.appendChild(s);
+  });
+</script>
 </body>
 </html>

--- a/tests/ai-assistant-ui.test.js
+++ b/tests/ai-assistant-ui.test.js
@@ -48,7 +48,7 @@ const assistants = ['terraform','helm','k8s','yaml','ansible','docker'];
 
 test('prompt mode persists across reloads for each assistant page', () => {
   for (const key of assistants){
-    const dom1 = createDom(`ai-assistant-${key}`, {withExport:false});
+    const dom1 = createDom(`ai-assistant/${key}`, {withExport:false});
     const {window} = dom1;
     const ui = loadUiCommon(window);
     ui.initPromptModeControls();
@@ -57,7 +57,7 @@ test('prompt mode persists across reloads for each assistant page', () => {
     const storageKey = `devopsia.promptMode.${key}`;
     const saved = window.localStorage.getItem(storageKey);
     // simulate reload
-    const dom2 = createDom(`ai-assistant-${key}`, {withExport:false});
+    const dom2 = createDom(`ai-assistant/${key}`, {withExport:false});
     dom2.window.localStorage.setItem(storageKey, saved);
     const ui2 = loadUiCommon(dom2.window);
     ui2.initPromptModeControls();
@@ -68,7 +68,7 @@ test('prompt mode persists across reloads for each assistant page', () => {
 });
 
 test('secure button disabled for non-pro users', async () => {
-  const dom = createDom('ai-assistant-terraform');
+  const dom = createDom('ai-assistant/terraform');
   const {window} = dom;
   const ui = loadUiCommon(window);
   ui.initPromptModeControls();
@@ -81,7 +81,7 @@ test('secure button disabled for non-pro users', async () => {
 });
 
 test('non-Pro users cannot activate secure mode and receive toast', async () => {
-  const dom = createDom('ai-assistant-terraform');
+  const dom = createDom('ai-assistant/terraform');
   const {window} = dom;
   const ui = loadUiCommon(window);
   ui.initPromptModeControls();
@@ -96,7 +96,7 @@ test('non-Pro users cannot activate secure mode and receive toast', async () => 
 });
 
 test('mode buttons adopt export button styles', () => {
-  const dom = createDom('ai-assistant-terraform');
+  const dom = createDom('ai-assistant/terraform');
   const {window} = dom;
   const ui = loadUiCommon(window);
   ui.initPromptModeControls();


### PR DESCRIPTION
## Summary
- add accessible sidebar with accordion, profile/prompt links, and Firebase sign-out
- restructure assistant pages to load the sidebar dynamically with sticky layout
- tweak styles and Firebase init to support new sidebar and routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e399be8c832fba91673eb5ea986a