### PR TITLE
feat: apply emerald→teal gradient banner

### DIFF
--- a/docs/components/header.html
+++ b/docs/components/header.html
@@ -1,13 +1,15 @@
-<header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-  <div class="max-w-6xl mx-auto flex justify-between items-center">
+<header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
+  <div class="max-w-6xl mx-auto px-4 banner-inner">
     <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-    <nav class="hidden md:flex space-x-4 items-center">
+    <nav class="hidden md:flex items-center gap-4">
       <a href="/#features" class="hover:underline">Features</a>
       <a href="/pricing/" class="hover:underline">Pricing</a>
-      <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-      <a id="authButton" href="/login/" class="hover:underline">Logout</a>
     </nav>
-    <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
+    <div class="hidden md:flex items-center gap-2">
+      <a href="#" class="banner-cta" @click="open = false">Start Building</a>
+      <a id="authButton" href="/login/" class="hover:underline">Logout</a>
+    </div>
+    <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
       <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
@@ -20,7 +22,7 @@
     <nav class="flex flex-col p-4 space-y-2">
       <a href="/#features" class="block" @click="open = false">Features</a>
       <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-      <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
+      <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
       <a id="authButton" href="/login/" class="block" @click="open = false">Logout</a>
     </nav>
   </div>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -250,3 +250,65 @@ a {
 /* details/summary pointer + reset default marker */
 details > summary { list-style: none; }
 details > summary::-webkit-details-marker { display: none; }
+
+:root {
+  --brand-start: #16a34a; /* emerald-600 */
+  --brand-end:   #0ea5a4; /* teal-600 */
+  --banner-text: #ffffff;
+  --cta-bg:      #ef4444; /* red-500 */
+  --cta-bg-hov:  #dc2626; /* red-600 */
+  --header-min-h: 56px;   /* slim height */
+}
+
+/* Slim gradient banner */
+.gradient-banner {
+  background: linear-gradient(90deg, var(--brand-start) 0%, var(--brand-end) 100%);
+  color: var(--banner-text);
+  min-height: var(--header-min-h);
+}
+
+/* Compact vertical rhythm */
+.gradient-banner .banner-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  padding-block: .5rem;
+}
+
+@media (min-width: 768px) {
+  .gradient-banner .banner-inner {
+    padding-block: .625rem;
+  }
+}
+
+/* CTA button (kept red for contrast and urgency) */
+.banner-cta {
+  background: var(--cta-bg);
+  color: #fff;
+  border-radius: .5rem;
+  padding: .5rem .9rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+.banner-cta:hover,
+.banner-cta:focus-visible {
+  background: var(--cta-bg-hov);
+}
+
+/* Links in banner */
+.gradient-banner a {
+  color: #ffffff;
+}
+.gradient-banner a:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+/* Ensure content doesn't hide under a fixed header (if using fixed) */
+/* Uncomment if your header is position: fixed */
+/*
+body.with-fixed-header {
+  padding-top: var(--header-min-h);
+}
+*/

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,17 +11,19 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col font-sans bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
+  <header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
+    <div class="max-w-6xl mx-auto px-4 banner-inner">
       <a id="home-logo-btn" href="/" class="text-2xl font-normal font-brand pr-2">Devopsia</a>
-      <nav class="hidden md:flex space-x-4 items-center">
+      <nav class="hidden md:flex items-center gap-4">
         <a href="/#features" class="hover:underline">Features</a>
         <a href="/pricing/" class="hover:underline">Pricing</a>
         <a href="/behind-the-build/" class="hover:underline">Behind the Build</a>
-        <a id="cta-build-btn" href="/pricing/" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Let’s Build</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
       </nav>
-      <button @click="open = !open" class="ml-auto md:hidden order-last focus:outline-none mr-4">
+      <div class="hidden md:flex items-center gap-2">
+        <a id="cta-build-btn" href="/pricing/" class="banner-cta" @click="open = false">Let’s Build</a>
+        <a id="authButton" href="/login/" class="hover:underline">Login</a>
+      </div>
+      <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
         <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -35,7 +37,7 @@
         <a href="/#features" class="block" @click="open = false">Features</a>
         <a href="/pricing/" class="block" @click="open = false">Pricing</a>
         <a href="/behind-the-build/" class="block" @click="open = false">Behind the Build</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
+        <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
         <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
       </nav>
     </div>

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -11,16 +11,18 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
+  <header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
+    <div class="max-w-6xl mx-auto px-4 banner-inner">
       <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
+      <nav class="hidden md:flex items-center gap-4">
         <a href="/#features" class="hover:underline">Features</a>
         <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
       </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
+      <div class="hidden md:flex items-center gap-2">
+        <a href="#" class="banner-cta" @click="open = false">Start Building</a>
+        <a id="authButton" href="/login/" class="hover:underline">Login</a>
+      </div>
+      <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
         <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -33,7 +35,7 @@
       <nav class="flex flex-col p-4 space-y-2">
         <a href="/#features" class="block" @click="open = false">Features</a>
         <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
+        <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
         <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- add CSS variables and gradient banner styles
- slim header layout with new banner-inner wrapper and red CTA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f86f9010832f881aacd62fbccf7e