### PR TITLE
feat: enable prompt history deletion

### DIFF
--- a/docs/js/prompt-history.js
+++ b/docs/js/prompt-history.js
@@ -1,12 +1,21 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
-import { collection, query, orderBy, limit, getDocs, doc, updateDoc } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+import { collection, query, orderBy, limit, getDocs, doc, updateDoc, deleteDoc, writeBatch } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
 const loadingEl = document.getElementById('auth-loading');
 const contentEl = document.getElementById('protected-content');
 const listEl = document.getElementById('history-list');
 const exportJsonBtn = document.getElementById('export-json-btn');
 const exportCsvBtn = document.getElementById('export-csv');
+const clearAllBtn = document.getElementById('clear-all-btn');
+
+function showToast(message) {
+  const toast = document.createElement('div');
+  toast.textContent = message;
+  toast.className = 'fixed top-4 right-4 bg-gray-800 text-white py-2 px-4 rounded shadow z-50';
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 3000);
+}
 
 onAuthStateChanged(auth, async (user) => {
   if (!user || !user.emailVerified) {
@@ -19,7 +28,7 @@ onAuthStateChanged(auth, async (user) => {
   const exportHistory = async (type) => {
     try {
       const qAll = query(
-        collection(db, 'users', user.uid, 'prompts'),
+        collection(db, 'users', user.uid, 'history'),
         orderBy('createdAt', 'desc')
       );
       const snapAll = await getDocs(qAll);
@@ -66,14 +75,15 @@ onAuthStateChanged(auth, async (user) => {
   if (exportCsvBtn) exportCsvBtn.addEventListener('click', () => exportHistory('csv'));
   try {
     const q = query(
-      collection(db, 'users', user.uid, 'prompts'),
+      collection(db, 'users', user.uid, 'history'),
       orderBy('createdAt', 'desc'),
       limit(50)
     );
     const snap = await getDocs(q);
     snap.forEach((docSnap) => {
       const data = docSnap.data();
-      const item = document.createElement('div');
+      const item = document.createElement('li');
+      item.dataset.id = docSnap.id;
       item.className = 'border rounded p-4 bg-gray-50';
       if (data.isFavorite) item.classList.add('bg-yellow-50');
 
@@ -105,6 +115,11 @@ onAuthStateChanged(auth, async (user) => {
       dateSpan.textContent = date ? date.toLocaleString() : '';
       meta.appendChild(modeSpan);
       meta.appendChild(dateSpan);
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'delete-entry text-red-500 hover:text-red-700 text-sm ml-2';
+      deleteBtn.textContent = '🗑️ Delete';
+      meta.appendChild(deleteBtn);
       if (data.isFavorite) {
         const favSpan = document.createElement('span');
         favSpan.className = 'text-yellow-500 ml-2';
@@ -128,7 +143,7 @@ onAuthStateChanged(auth, async (user) => {
         e.stopPropagation();
         const newVal = !data.isFavorite;
         try {
-          await updateDoc(doc(db, 'users', user.uid, 'prompts', docSnap.id), { isFavorite: newVal });
+          await updateDoc(doc(db, 'users', user.uid, 'history', docSnap.id), { isFavorite: newVal });
           data.isFavorite = newVal;
           starBtn.textContent = newVal ? '⭐' : '☆';
           if (newVal) {
@@ -152,5 +167,42 @@ onAuthStateChanged(auth, async (user) => {
     });
   } catch (err) {
     console.error('Failed to load prompt history', err);
+  }
+
+  if (listEl) {
+    listEl.addEventListener('click', async (e) => {
+      const btn = e.target.closest('.delete-entry');
+      if (!btn) return;
+      e.stopPropagation();
+      const li = btn.closest('li');
+      const entryId = li?.dataset.id;
+      if (!entryId) return;
+      li.remove();
+      try {
+        await deleteDoc(doc(db, 'users', user.uid, 'history', entryId));
+        showToast('Entry deleted');
+      } catch (err) {
+        console.error('Failed to delete entry', err);
+      }
+    }, true);
+  }
+
+  if (clearAllBtn) {
+    clearAllBtn.addEventListener('click', async () => {
+      if (!confirm('Are you sure you want to delete all history?')) return;
+      try {
+        const qAll = query(collection(db, 'users', user.uid, 'history'));
+        const snapAll = await getDocs(qAll);
+        const batch = writeBatch(db);
+        snapAll.forEach((d) => {
+          batch.delete(doc(db, 'users', user.uid, 'history', d.id));
+        });
+        await batch.commit();
+        if (listEl) listEl.innerHTML = '';
+        showToast('All history cleared');
+      } catch (err) {
+        console.error('Failed to clear history', err);
+      }
+    });
   }
 });

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -19,21 +19,24 @@
       <main id="main-content" class="flex-1 p-6 bg-white">
         <nav class="text-sm text-gray-500 mb-2"><a href="/">Home</a> / Prompt History</nav>
         <h1 class="text-2xl font-semibold mb-4">Prompt History</h1>
-        <!-- Action buttons: Save to Favorites and export options -->
+        <!-- Action buttons: Save to Favorites, export options, and clear all -->
         <div class="flex flex-col sm:flex-row justify-end items-center gap-4 mt-4 mb-6">
           <button id="save-favorites" type="button" class="bg-yellow-400 hover:bg-yellow-500 text-black font-semibold text-sm py-2 px-4 rounded shadow">
             ⭐ Save to Favorites
           </button>
-          <div class="flex gap-2">
+          <div class="flex gap-2 items-center">
             <button id="export-json-btn" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
               Export JSON
             </button>
             <button id="export-csv" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
               Export CSV
             </button>
+            <button id="clear-all-btn" class="bg-red-500 hover:bg-red-600 text-white text-sm px-3 py-1 rounded shadow">
+              Clear All
+            </button>
           </div>
         </div>
-        <div id="history-list" class="space-y-4"></div>
+        <ul id="history-list" class="space-y-4 list-none"></ul>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add per-entry and bulk delete controls on prompt history page
- wire deletion actions to Firestore history collection with toast notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a84d8e5e14832fa446481872c3b413