### PR TITLE
feat: add base css and update prompt history page

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -1,0 +1,100 @@
+/* ===== Design Tokens ===== */
+:root{
+  /* Colors */
+  --bg: #ffffff;
+  --fg: #1f2937;       /* gray-800 */
+  --muted: #4b5563;    /* gray-600 */
+  --border: #e5e7eb;   /* gray-200 */
+  --panel: #f9fafb;    /* gray-50 */
+  --panel-2: #f3f4f6;  /* gray-100 */
+  --brand: #16a34a;    /* green-600 */
+  --brand-contrast: #ffffff;
+  --danger: #ef4444;
+  --danger-strong: #b91c1c;
+
+  /* Radius, spacing, shadow */
+  --r-sm: .25rem;
+  --r-md: .375rem;
+  --r-lg: .5rem;
+  --pad-2: .5rem;
+  --pad-3: .75rem;
+  --pad-4: 1rem;
+  --gap-2: .5rem;
+  --gap-3: .75rem;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.05);
+  --container: 72rem; /* 1152px */
+}
+
+/* ===== Resets & helpers ===== */
+.hidden{display:none!important;}
+.nowrap{white-space:nowrap;}
+.break-words{overflow-wrap:break-word;word-break:break-word;}
+.code{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;}
+
+/* ===== Layout utilities ===== */
+.container{max-width:var(--container);margin-inline:auto;padding-inline:1rem;}
+.flex{display:flex;}
+.grid{display:grid;}
+.items-center{align-items:center;}
+.justify-between{justify-content:space-between;}
+.justify-end{justify-content:flex-end;}
+.gap-2{gap:var(--gap-2);}
+.gap-3{gap:var(--gap-3);}
+
+/* ===== Spacing ===== */
+.p-2{padding:var(--pad-2);}
+.p-3{padding:var(--pad-3);}
+.p-4{padding:var(--pad-4);}
+.px-3{padding-inline:var(--pad-3);}
+.py-1{padding-block:.25rem;}
+.mt-2{margin-top:.5rem;}
+.mr-2{margin-right:.5rem;}
+.ml-2{margin-left:.5rem;}
+
+/* ===== Typography ===== */
+.text{color:var(--fg);}
+.text-muted{color:var(--muted);}
+.text-danger{color:var(--danger);}
+.text-xs{font-size:.75rem;line-height:1rem;}
+.text-sm{font-size:.875rem;line-height:1.25rem;}
+.bold{font-weight:600;}
+
+/* ===== Surfaces ===== */
+.card{
+  background:var(--bg);
+  border:1px solid var(--border);
+  border-radius:var(--r-lg);
+  box-shadow:var(--shadow-sm);
+  padding:var(--pad-4);
+}
+
+/* ===== Buttons ===== */
+.btn{
+  display:inline-flex;align-items:center;justify-content:center;gap:.375rem;
+  font-size:.875rem;line-height:1.25rem;font-weight:600;
+  padding:.5rem .75rem;border-radius:var(--r-md);
+  border:1px solid transparent;cursor:pointer;text-decoration:none;
+}
+.btn:focus-visible{outline:2px solid #111;outline-offset:2px;}
+.btn-ghost{background:#e5e7eb;color:#111;border-color:#e5e7eb;}
+.btn-ghost:hover{background:#d1d5db;}
+.btn-danger{background:var(--danger);color:#fff;}
+.btn-danger:hover{background:var(--danger-strong);}
+.icon-btn{width:24px;height:24px;border-radius:var(--r-sm);display:flex;align-items:center;justify-content:center;}
+
+/* ===== Badges ===== */
+.badge{display:inline-block;font-size:.75rem;padding:.25rem .5rem;border-radius:var(--r-md);background:var(--panel-2);}
+
+/* ===== Prompt History components ===== */
+history-item{comp:initial;} /* marker for grep */
+.history-item{background:#fff;border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:var(--shadow-sm);padding:var(--pad-4);}
+.history-grid{display:grid;align-items:center;gap:var(--gap-3);grid-template-columns:40px 1fr auto;}
+.star-btn{width:24px;height:24px;display:flex;align-items:center;justify-content:center;line-height:1;font-size:1.25rem;cursor:pointer;}
+.prompt-text{color:var(--fg);}
+.history-item.is-collapsed .prompt-text{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;}
+.meta-wrap{display:flex;align-items:center;gap:var(--gap-3);justify-content:flex-end;font-size:.875rem;color:var(--muted);}
+.history-body{margin-top:.5rem;white-space:pre-wrap;font-size:.875rem;background:var(--panel);padding:.75rem;border-radius:var(--r-md);border:1px solid var(--border);}
+@media (max-width:640px){
+  .history-grid{grid-template-columns:40px 1fr;}
+  .meta-wrap{grid-column:1 / -1;justify-content:flex-start;margin-top:.5rem;}
+}

--- a/docs/js/prompt-history.js
+++ b/docs/js/prompt-history.js
@@ -6,7 +6,7 @@ const loadingEl = document.getElementById('auth-loading');
 const contentEl = document.getElementById('protected-content');
 const listEl = document.getElementById('history-list');
 const exportJsonBtn = document.getElementById('export-json-btn');
-const exportCsvBtn = document.getElementById('export-csv');
+const exportCsvBtn = document.getElementById('export-csv-btn');
 const emptyEl = document.getElementById('history-empty');
 
 function refreshEmptyState() {
@@ -163,14 +163,14 @@ onAuthStateChanged(auth, async (user) => {
         const metaCol = document.createElement('div');
         metaCol.className = 'meta-wrap';
         const modeSpan = document.createElement('span');
-        modeSpan.className = 'mode-badge';
+        modeSpan.className = 'badge';
         modeSpan.textContent = data.mode || data.profile || 'default';
         const dateSpan = document.createElement('span');
         const date = data.createdAt?.toDate ? data.createdAt.toDate() : null;
         dateSpan.textContent = date ? date.toLocaleString() : '';
         const deleteBtn = document.createElement('button');
         deleteBtn.type = 'button';
-        deleteBtn.className = 'delete-entry text-red-500 hover:text-red-700';
+        deleteBtn.className = 'delete-entry btn btn-ghost text-danger';
         deleteBtn.textContent = 'Delete';
         metaCol.appendChild(modeSpan);
         metaCol.appendChild(dateSpan);

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Prompt History - Devopsia</title>
+  <link rel="stylesheet" href="/css/base.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
@@ -17,24 +18,15 @@
     <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
-        <nav class="text-sm text-gray-500 mb-2"><a href="/">Home</a> / Prompt History</nav>
-        <h1 class="text-2xl font-semibold mb-4">Prompt History</h1>
-        <!-- Action buttons: Save to Favorites and export options -->
-        <div class="flex items-center gap-2 justify-end mt-4 mb-6">
-          <button id="save-favorites" type="button" class="bg-yellow-400 hover:bg-yellow-500 text-black font-semibold text-sm py-2 px-4 rounded shadow">
-            ⭐ Save to Favorites
-          </button>
-          <button id="export-json-btn" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
-            Export JSON
-          </button>
-          <button id="export-csv" type="button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold text-sm py-2 px-4 rounded shadow">
-            Export CSV
-          </button>
-          <button id="clear-all-btn" class="bg-red-500 hover:bg-red-600 text-white text-sm px-3 py-1 rounded shadow">
-            Clear All
-          </button>
+        <div class="container flex items-center justify-between p-4">
+          <nav class="text-muted text-sm"><a href="/">Home</a> / Prompt History</nav>
+          <div class="flex items-center gap-2">
+            <button id="export-json-btn" class="btn btn-ghost">Export JSON</button>
+            <button id="export-csv-btn" class="btn btn-ghost">Export CSV</button>
+            <button id="clear-all-btn" class="btn btn-danger">Clear All</button>
+          </div>
         </div>
-        <ul id="history-list" class="space-y-4"></ul>
+        <ul id="history-list" class="container p-4"></ul>
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add shared `base.css` with design tokens, utilities, and components
- update Prompt History page markup to use new CSS utilities
- refactor prompt history script to output new class names and controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a880cbb8a0832fa2c9485f4450e809