### PR TITLE
Fix header buttons by scoping hidden utility

### DIFF
--- a/docs/css/base.css
+++ b/docs/css/base.css
@@ -26,7 +26,7 @@
 }
 
 /* ===== Resets & helpers ===== */
-.hidden{display:none!important;}
+.u-hidden{display:none!important;}
 .nowrap{white-space:nowrap;}
 .break-words{overflow-wrap:break-word;word-break:break-word;}
 .code{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;}
@@ -40,6 +40,7 @@
 .justify-end{justify-content:flex-end;}
 .gap-2{gap:var(--gap-2);}
 .gap-3{gap:var(--gap-3);}
+.nav-actions{display:flex;align-items:center;gap:.5rem;}
 
 /* ===== Spacing ===== */
 .p-2{padding:var(--pad-2);}

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -384,7 +384,7 @@ body.with-fixed-header {
 }
 
 /* robust hidden helper (works even without Tailwind) */
-.hidden { display: none !important; }
+.u-hidden { display: none !important; }
 
 /* Responsive: stack meta under prompt on small screens */
 @media (max-width: 640px) {

--- a/docs/js/prompt-history.js
+++ b/docs/js/prompt-history.js
@@ -11,7 +11,7 @@ const emptyEl = document.getElementById('history-empty');
 
 function refreshEmptyState() {
   if (!emptyEl) return;
-  emptyEl.classList.toggle('hidden', listEl.children.length > 0);
+  emptyEl.classList.toggle('u-hidden', listEl.children.length > 0);
 }
 
 // Which subcollection holds history? prefer "history", fallback to "prompts"
@@ -70,8 +70,8 @@ onAuthStateChanged(auth, async (user) => {
     window.location.replace('/login/');
     return;
   }
-  if (loadingEl) loadingEl.classList.add('hidden');
-  if (contentEl) contentEl.classList.remove('hidden');
+  if (loadingEl) loadingEl.classList.add('u-hidden');
+  if (contentEl) contentEl.classList.remove('u-hidden');
 
   await detectHistoryCollection(user.uid);
 
@@ -152,7 +152,7 @@ onAuthStateChanged(auth, async (user) => {
         toggleBtn.textContent = '\u25B6 Expand';
 
         const body = document.createElement('pre');
-        body.className = 'history-body hidden';
+        body.className = 'history-body u-hidden';
         body.textContent = data.response || data.output || '';
 
         promptCol.appendChild(title);
@@ -188,14 +188,14 @@ onAuthStateChanged(auth, async (user) => {
         toggleBtn.addEventListener('click', (e) => {
           e.stopPropagation();
           const collapsed = item.classList.toggle('is-collapsed');
-          body.classList.toggle('hidden', collapsed);
+          body.classList.toggle('u-hidden', collapsed);
           toggleBtn.textContent = collapsed ? '\u25B6 Expand' : '\u25BC Collapse';
         });
 
         // Optional: expand on title click
         title.addEventListener('click', (e) => {
           const collapsed = item.classList.toggle('is-collapsed');
-          body.classList.toggle('hidden', collapsed);
+          body.classList.toggle('u-hidden', collapsed);
           toggleBtn.textContent = collapsed ? '\u25B6 Expand' : '\u25BC Collapse';
         });
 

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -13,7 +13,7 @@
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
+  <div id="protected-content" class="u-hidden">
     <div id="header-container"></div>
     <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>


### PR DESCRIPTION
## Summary
- Replace global `.hidden` rule with scoped `.u-hidden` and add `.nav-actions` helper
- Update Prompt History styles, markup, and script to toggle `u-hidden`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8919592b0832f94559343f6154dbe