### PR TITLE
feat: add reusable header and site pages

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -11,34 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <div class="container pt-20">
+  <div id="top-banner"></div>
+    <div class="container pt-20">
   <main>
     <div class="card">
       <h1>About</h1>
@@ -49,5 +23,6 @@
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for Ansible</h1>
@@ -42,7 +42,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -50,8 +49,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -64,6 +62,7 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for Docker</h1>
@@ -42,7 +42,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -50,8 +49,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -64,6 +62,7 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for Helm</h1>
@@ -42,7 +42,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -50,8 +49,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -64,6 +62,7 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for K8s</h1>
@@ -42,7 +42,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -50,8 +49,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -64,5 +62,6 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for Terraform</h1>
@@ -41,7 +41,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -49,8 +48,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -63,6 +61,7 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -11,10 +11,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <h1 class="text-2xl font-semibold mb-4">AI Assistant for YAML</h1>
@@ -42,7 +42,6 @@
           <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
           <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
         </div>
-        <div id="footer-container"></div>
       </main>
     </div>
   </div>
@@ -50,8 +49,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -64,6 +62,7 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>
 

--- a/docs/behind-the-build/index.html
+++ b/docs/behind-the-build/index.html
@@ -11,36 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <a id="home-logo-btn" href="/" class="text-2xl font-normal font-brand pr-2">Devopsia</a>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="/behind-the-build/" class="hover:underline">Behind the Build</a>
-        <a href="/pricing/" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Let’s Build</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="/behind-the-build/" class="block" @click="open = false">Behind the Build</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-
+  <div id="top-banner"></div>
+  
   <main class="container mx-auto px-4 pt-24 pb-16 max-w-3xl">
     <h1 class="text-3xl font-bold mb-2">Behind the Build</h1>
     <p class="text-gray-600 text-lg mb-10">Why we’re building Devopsia — and where we’re going next.</p>
@@ -74,5 +46,6 @@
   <footer class="text-center py-4">© 2025 Devopsia</footer>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/components/header.html
+++ b/docs/components/header.html
@@ -1,29 +1,20 @@
-<header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
-  <div class="max-w-6xl mx-auto px-4 banner-inner">
-    <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-    <nav class="hidden md:flex items-center gap-4">
-      <a href="/#features" class="hover:underline">Features</a>
-      <a href="/pricing/" class="hover:underline">Pricing</a>
-    </nav>
-    <div class="hidden md:flex items-center gap-2">
-      <a href="#" class="banner-cta" @click="open = false">Start Building</a>
-      <a id="authButton" href="/login/" class="hover:underline">Logout</a>
-    </div>
-    <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
-      <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-      <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-      </svg>
-    </button>
-  </div>
-  <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-    <nav class="flex flex-col p-4 space-y-2">
-      <a href="/#features" class="block" @click="open = false">Features</a>
-      <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-      <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
-      <a id="authButton" href="/login/" class="block" @click="open = false">Logout</a>
+<header class="site-header" role="banner">
+  <div class="site-header__inner">
+    <a href="/" class="site-header__logo-link" aria-label="Devopsia Home">
+      <img src="/assets/Cloud DevOps Logo_simple.png" alt="Devopsia" class="site-header__logo">
+    </a>
+
+    <nav class="site-nav" aria-label="Primary">
+      <ul class="site-nav__list">
+        <li><a href="/" data-nav="home" class="site-nav__link">Home</a></li>
+        <li><a href="/product/" data-nav="product" class="site-nav__link">Product</a></li>
+        <li><a href="/resources/" data-nav="resources" class="site-nav__link">Resources</a></li>
+        <li>
+          <a href="/login/" class="site-cta">
+            Let’s build
+          </a>
+        </li>
+      </ul>
     </nav>
   </div>
 </header>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -11,34 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <div class="container pt-20">
+  <div id="top-banner"></div>
+    <div class="container pt-20">
   <main>
     <div class="card">
       <h1>Contact</h1>
@@ -49,5 +23,6 @@
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -126,26 +126,9 @@ img {
   margin-bottom: 2rem;
 }
 
-header, footer {
+footer {
   text-align: center;
   margin-bottom: 2rem;
-}
-
-/* Navigation bar with rounded corners and gradient */
-.site-header {
-  /* shorter navigation bar with soft rounded corners */
-  padding: 0.5rem 1rem;
-  border-radius: 1rem;
-  /* subtle transparent gradient */
-  background: linear-gradient(90deg,
-      rgba(249, 115, 22, 0.7),
-      rgba(249, 115, 22, 0));
-  color: #ffffff;
-}
-
-header a {
-  display: block;
-  margin: 0.5rem 0;
 }
 
 a {
@@ -179,6 +162,7 @@ a {
   outline: 2px solid #F97316;
   transition: outline 0.3s ease-in-out;
 }
+
 
 /* Styled output container for AI assistant */
 #output {
@@ -397,3 +381,97 @@ body.with-fixed-header {
     margin-top: 0.5rem;
   }
 }
+
+/* Reusable site header */
+.site-header {
+  background: #F4F4F2;
+  border-bottom: 1px solid #0D0E0C;
+  color: #0D0E0C;
+  text-align: left;
+  margin-bottom: 0;
+}
+
+.site-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.site-header__logo {
+  height: 36px;
+  width: auto;
+  display: block;
+}
+
+.site-nav__list {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 3vw, 20px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav__link {
+  text-decoration: none;
+  color: #0D0E0C;
+  font-weight: 500;
+  padding: 6px 8px;
+  border-radius: 8px;
+  transition: background 0.15s ease;
+}
+
+.site-nav__link:hover {
+  background: rgba(13,14,12,0.06);
+}
+
+.site-nav__link.is-active {
+  outline: 1px solid #0D0E0C;
+  background: rgba(13,14,12,0.06);
+}
+
+.site-cta {
+  text-decoration: none;
+  display: inline-block;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid #0D0E0C;
+  background: white;
+  color: #0D0E0C;
+  font-weight: 600;
+  transition: transform 0.06s ease, background 0.15s ease;
+}
+
+.site-cta:hover {
+  background: #F4F4F2;
+}
+
+.site-cta:active {
+  transform: translateY(1px);
+}
+
+/* Optional: make header sticky if desired
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+*/
+
+/* Layout helpers */
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.breadcrumb {
+  font-size: 0.9rem;
+  margin-bottom: 12px;
+}
+
+.breadcrumb a { color: inherit; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,38 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col font-sans bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto px-4 banner-inner">
-      <a id="home-logo-btn" href="/" class="text-2xl font-normal font-brand pr-2">Devopsia</a>
-      <nav class="hidden md:flex items-center gap-4">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="/behind-the-build/" class="hover:underline">Behind the Build</a>
-      </nav>
-      <div class="hidden md:flex items-center gap-2">
-        <a id="cta-build-btn" href="/pricing/" class="banner-cta" @click="open = false">Let’s Build</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </div>
-      <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="/behind-the-build/" class="block" @click="open = false">Behind the Build</a>
-        <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-
+  <div id="top-banner"></div>
+  
   <section class="container mx-auto text-center py-12 md:py-20">
     <h1 class="text-4xl md:text-6xl font-medium font-tagline mb-4">Your AI DevOps Engineer</h1>
     <p class="text-lg md:text-2xl mb-10">Type your infra task. Get instant, ready-to-run code.</p>
@@ -145,5 +115,6 @@
   </script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/js/header.js
+++ b/docs/js/header.js
@@ -1,17 +1,46 @@
-async function loadFragment(id, url) {
-  const el = document.getElementById(id);
-  if (!el) return;
-  try {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Failed to load ${url}`);
-    el.innerHTML = await res.text();
-  } catch (err) {
-    console.error(err);
-  }
-}
+// /docs/js/header.js
+(function () {
+  const mount = document.getElementById('top-banner');
+  if (!mount) return;
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await loadFragment('header-container', '/components/header.html');
-  document.dispatchEvent(new Event('header-loaded'));
-  await loadFragment('footer-container', '/components/footer.html');
-});
+  fetch('/components/header.html', { cache: 'no-cache' })
+    .then(res => res.text())
+    .then(html => {
+      mount.innerHTML = html;
+
+      // Active link logic by pathname prefix
+      const path = window.location.pathname.replace(/\/index\.html$/, '');
+      const map = [
+        { key: 'home', test: p => p === '/' || p === '' },
+        { key: 'product', test: p => p.startsWith('/product') },
+        { key: 'resources', test: p => p.startsWith('/resources') },
+      ];
+      const match = map.find(m => m.test(path));
+      if (match) {
+        const active = mount.querySelector(`a[data-nav="${match.key}"]`);
+        if (active) active.classList.add('is-active');
+      }
+
+      // Ensure page content doesn’t slide under fixed header (if fixed later)
+      const header = mount.querySelector('.site-header');
+      if (header) {
+        const next = mount.nextElementSibling;
+        if (next && !next.dataset.headerAdjusted) {
+          const rect = header.getBoundingClientRect();
+          const h = Math.ceil(rect.height);
+          if (h > 0) {
+            const style = window.getComputedStyle(header);
+            const position = style.position;
+            if (position === 'fixed' || position === 'sticky') {
+              next.style.scrollMarginTop = h + 'px';
+              next.style.paddingTop = 'clamp(8px, 2vw, 16px)';
+              next.dataset.headerAdjusted = 'true';
+            }
+          }
+        }
+      }
+    })
+    .catch(err => {
+      console.error('Failed to load header:', err);
+    });
+})();

--- a/docs/kits/index.html
+++ b/docs/kits/index.html
@@ -11,34 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <div class="container pt-20">
+  <div id="top-banner"></div>
+    <div class="container pt-20">
   <main>
     <div class="card">
       <h1>Kits</h1>
@@ -49,5 +23,6 @@
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -18,34 +18,8 @@
   </style>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
+  <div id="top-banner"></div>
+    <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
     <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
       <h1 class="text-3xl font-extrabold mb-6 text-center">Sign In to Devopsia</h1>
       <form id="login-form" class="space-y-4">
@@ -68,5 +42,6 @@
   <script type="module" src="/js/login.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -11,36 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="gradient-banner fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto px-4 banner-inner">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex items-center gap-4">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-      </nav>
-      <div class="hidden md:flex items-center gap-2">
-        <a href="#" class="banner-cta" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </div>
-      <button @click="open = !open" class="ml-auto md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="banner-cta block text-center" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-
+  <div id="top-banner"></div>
+  
   <main class="container mx-auto py-20 flex-grow">
     <h1 class="text-4xl font-extrabold text-center mb-8">Pricing</h1>
     <div class="flex justify-center mb-8" role="group" aria-label="Pricing toggle">
@@ -219,5 +191,6 @@
       }
     };
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -11,34 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <div class="container pt-20">
+  <div id="top-banner"></div>
+    <div class="container pt-20">
   <main>
     <div class="card">
       <h1>🔐 Devopsia Privacy Policy</h1>
@@ -110,5 +84,6 @@
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Devopsia — Product</title>
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <div id="top-banner"></div>
+
+  <main class="container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> / <span>Product</span>
+    </nav>
+
+    <h1>Product</h1>
+    <p>This page is under construction. We’ll detail the platform, assistants, and automations here.</p>
+  </main>
+
+  <script src="/js/header.js"></script>
+</body>
+</html>

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -9,17 +9,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
+  <div id="top-banner"></div>
   <!-- Top header -->
-  <header class="sticky top-0 z-40 bg-white/90 backdrop-blur border-b border-gray-200">
-    <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-      <a href="/" class="font-semibold text-lg">Devopsia</a>
-      <nav class="flex items-center gap-4 text-sm">
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a id="nav-ai" href="/ai-assistant-terraform/" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-red-500 text-white hover:bg-red-600 transition">Start Building</a>
-      </nav>
-    </div>
-  </header>
-
+  
   <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
 
     <!-- Sidebar -->
@@ -289,5 +281,6 @@
       if (status === 'cancel')  showToast('Billing was canceled.', 'warn');
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -12,10 +12,10 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-700 font-sans">
+  <div id="top-banner"></div>
   <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
   <div id="protected-content" class="u-hidden">
-    <div id="header-container"></div>
-    <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
+        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
       <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
       <main id="main-content" class="flex-1 p-6 bg-white">
         <div class="container flex items-center justify-between p-4">
@@ -33,8 +33,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/prompt-history.js"></script>
-  <script type="module" src="/js/header.js"></script>
-  <script>
+    <script>
     // Load sidebar include
     (async function() {
       const container = document.getElementById('sidebar-container');
@@ -47,5 +46,6 @@
       document.body.appendChild(s);
     })();
   </script>
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Devopsia — Resources</title>
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <div id="top-banner"></div>
+
+  <main class="container">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/">Home</a> / <span>Resources</span>
+    </nav>
+
+    <h1>Resources</h1>
+    <p>Docs, guides, and articles will live here.</p>
+  </main>
+
+  <script src="/js/header.js"></script>
+</body>
+</html>

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -19,34 +19,8 @@
   <script type="module" src="/js/signup.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
+  <div id="top-banner"></div>
+    <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
     <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
       <h1 class="text-3xl font-extrabold mb-6 text-center">Create your account</h1>
       <form id="signupForm" class="space-y-4">
@@ -153,5 +127,6 @@
 
   <script type="module" src="/js/auth.js"></script>
 
+  <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -11,34 +11,8 @@
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
-  <header x-data="{ open: false }" class="site-header text-white px-4 py-3 fixed top-0 inset-x-0 z-50">
-    <div class="max-w-6xl mx-auto flex justify-between items-center">
-      <div class="text-2xl font-normal font-brand pr-2">Devopsia</div>
-      <nav class="hidden md:flex space-x-4 items-center">
-        <a href="/#features" class="hover:underline">Features</a>
-        <a href="/pricing/" class="hover:underline">Pricing</a>
-        <a href="#" class="start-button bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="hover:underline">Login</a>
-      </nav>
-      <button @click="open = !open" class="ml-auto order-last md:hidden focus:outline-none mr-4">
-        <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        <svg x-show="open" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
-    <div x-show="open" x-transition:enter="transition-all duration-300 ease-in-out" x-transition:enter-start="opacity-0 -translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" x-transition:leave="transition-all duration-300 ease-in-out" x-transition:leave-start="opacity-100 translate-y-0" x-transition:leave-end="opacity-0 -translate-y-2" class="absolute top-full left-0 w-full bg-white text-gray-800 shadow-md z-50 rounded-b md:hidden" @click.away="open = false" x-cloak>
-      <nav class="flex flex-col p-4 space-y-2">
-        <a href="/#features" class="block" @click="open = false">Features</a>
-        <a href="/pricing/" class="block" @click="open = false">Pricing</a>
-        <a href="#" class="start-button bg-red-600 text-white px-4 py-2 rounded block" @click="open = false">Start Building</a>
-        <a id="authButton" href="/login/" class="block" @click="open = false">Login</a>
-      </nav>
-    </div>
-  </header>
-  <div class="container pt-20">
+  <div id="top-banner"></div>
+    <div class="container pt-20">
   <main>
     <div class="card">
       <h1>🧾 Devopsia Terms of Service</h1>
@@ -97,5 +71,6 @@
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
+  <script src="/js/header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build reusable site header with logo, new navigation, and login CTA
- load header dynamically and highlight active nav items
- add Product and Resources pages and update site styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c21d6c84832f964ff2301fc11074