### PR TITLE
Add Sign Out action to sidebar

### DIFF
--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -32,12 +32,8 @@
     <a href="/prompt-history/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1" data-link="prompt-history">
       <span>Prompt History</span>
     </a>
-  </div>
-
-  <!-- Bottom: Sign Out -->
-  <div class="mt-auto p-4 border-t border-gray-200">
-    <button id="sidebar-signout" type="button" class="w-full text-left px-3 py-2 rounded bg-gray-50 hover:bg-gray-100">
+    <button id="signout-btn" type="button" class="sidebar-btn flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1">
       Sign Out
     </button>
-  </div>
-</nav>
+    </div>
+  </nav>

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -1,14 +1,13 @@
 // Requires Firebase Auth already initialized
 (function () {
-  const signOutBtn = document.getElementById('sidebar-signout');
+  const signOutBtn = document.getElementById('signout-btn');
   if (signOutBtn && window.firebase?.auth) {
     signOutBtn.addEventListener('click', async () => {
       try {
         await firebase.auth().signOut();
-        window.location.href = '/';
+        window.location.href = '/login/';
       } catch (e) {
         console.error('Sign out failed:', e);
-        alert('Sign out failed. See console for details.');
       }
     });
   }


### PR DESCRIPTION
## Summary
- show Sign Out button directly under Prompt History in sidebar
- hook Sign Out button to Firebase Auth sign out and redirect to `/login/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95d687214832fb352e2f6f7c5d91e