### PR TITLE
Refactor AI assistant pages sign out handling

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -10,57 +10,106 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Ansible</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for Ansible</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
-          <input type="hidden" id="tool" value="ansible">
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
+        <input type="hidden" id="tool" value="ansible">
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -10,57 +10,106 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Docker</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for Docker</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
-          <input type="hidden" id="tool" value="docker">
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
+        <input type="hidden" id="tool" value="docker">
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -10,57 +10,106 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Helm</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for Helm</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
-          <input type="hidden" id="tool" value="helm">
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
+        <input type="hidden" id="tool" value="helm">
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -10,58 +10,108 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for K8s</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for K8s</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
-          <input type="hidden" id="tool" value="k8s">
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
+        <input type="hidden" id="tool" value="k8s">
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>
 </html>
+

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -10,56 +10,105 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for Terraform</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for Terraform</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -10,57 +10,106 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="bg-gray-50 text-gray-700 font-sans">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-  <div id="auth-loading" class="flex items-center justify-center min-h-screen">Checking authentication...</div>
-  <div id="protected-content" class="hidden">
-        <div class="with-sidebar px-4 lg:px-6 pt-16 min-h-screen">
-      <div id="sidebar-container" class="lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"></div>
-      <main id="main-content" class="flex-1 p-6 bg-white">
-        <h1 class="text-2xl font-semibold mb-4">AI Assistant for YAML</h1>
-        <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
-          <div>
-            <div class="flex items-center mb-1">
-              <span class="block text-sm font-medium">Prompt Mode</span>
-              <div class="relative group ml-1">
-                <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
-                <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
-                  Secure mode restricts Claude to safe, validated infrastructure generation.
-                </div>
-              </div>
-            </div>
-            <div class="mode-toolbar mb-4">
-              <div id="prompt-mode-buttons">
-                <button class="btn-mode" data-mode="default">Default</button>
-                <button class="btn-mode" data-mode="optimized">Optimized</button>
-                <button class="btn-mode" data-mode="secure">Secure</button>
+
+  <div class="max-w-6xl mx-auto px-4 grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
+    <aside id="sidebar-container" class="md:col-span-3"></aside>
+
+    <main class="md:col-span-9">
+      <!-- Breadcrumbs -->
+      <div class="text-sm text-gray-500 mb-3">
+        <a href="/" class="hover:underline">Home</a> / <span class="text-gray-700">AI Assistant</span>
+      </div>
+
+      <h1 class="text-2xl font-semibold mb-4">AI Assistant for YAML</h1>
+      <div x-data="promptComponent()" id="promptContainer" class="bg-white p-6 rounded-lg shadow space-y-4">
+        <div>
+          <div class="flex items-center mb-1">
+            <span class="block text-sm font-medium">Prompt Mode</span>
+            <div class="relative group ml-1">
+              <button class="text-sm text-gray-500 hover:text-blue-600">ⓘ</button>
+              <div class="absolute top-full mt-2 w-64 p-2 bg-white border border-gray-200 rounded shadow-lg text-sm hidden group-hover:block z-50">
+                Secure mode restricts Claude to safe, validated infrastructure generation.
               </div>
             </div>
           </div>
-          <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your YAML question..."></textarea>
-          <input type="hidden" id="tool" value="yaml">
-          <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
-          <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+          <div class="mode-toolbar mb-4">
+            <div id="prompt-mode-buttons">
+              <button class="btn-mode" data-mode="default">Default</button>
+              <button class="btn-mode" data-mode="optimized">Optimized</button>
+              <button class="btn-mode" data-mode="secure">Secure</button>
+            </div>
+          </div>
         </div>
-      </main>
-    </div>
+        <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your YAML question..."></textarea>
+        <input type="hidden" id="tool" value="yaml">
+        <button id="runPrompt" class="bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-4 rounded w-full">Run Prompt</button>
+        <pre id="result" class="bg-gray-100 p-4 rounded overflow-x-auto whitespace-pre-wrap"></pre>
+      </div>
+    </main>
   </div>
+
+  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
+
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
-    <script>
-    // Load sidebar include
-    (async function() {
-      const container = document.getElementById('sidebar-container');
-      if (!container) return;
-      const res = await fetch('/components/sidebar.html', { cache: 'no-cache' });
-      container.innerHTML = await res.text();
-      // After injecting HTML, load JS
-      const s = document.createElement('script');
-      s.src = '/js/sidebar.js';
-      document.body.appendChild(s);
+
+  <!-- Firebase + page scripts -->
+  <script src="/js/firebase-init.js"></script>
+  <script>
+    // Toast (optional but nice to keep consistent with /profile)
+    function showToast(msg, type = 'info') {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        document.body.appendChild(el);
+      }
+      const palette = {
+        info:  ['bg-gray-900','text-white'],
+        success:['bg-green-600','text-white'],
+        error: ['bg-red-600','text-white'],
+        warn:  ['bg-orange-600','text-white'],
+      }[type] || ['bg-gray-900','text-white'];
+      el.className = 'fixed bottom-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg text-sm ' + palette.join(' ');
+      el.textContent = msg;
+      el.style.opacity = '1';
+      el.classList.remove('hidden');
+      setTimeout(() => { el.style.opacity = '0'; }, 2200);
+      setTimeout(() => { el.classList.add('hidden'); }, 2600);
+    }
+
+    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    (async function loadSidebar(){
+      try {
+        const res = await fetch('/components/sidebar.html', { cache:'no-store' });
+        const html = await res.text();
+        const ctn = document.getElementById('sidebar-container');
+        if (ctn) ctn.innerHTML = html;
+
+        // highlight here (fallback; sidebar.js also does it)
+        const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+        if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+
+        // important: load the sidebar behavior after HTML is in DOM
+        const s = document.createElement('script');
+        s.src = '/js/sidebar.js';
+        document.body.appendChild(s);
+      } catch(e) {
+        console.error('Sidebar load failed', e);
+      }
     })();
+
+    // Auth guard for assistant pages
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        window.location.href = '/login/';
+      }
+      // If you require verified emails here, add the check similar to /profile
+    });
   </script>
   <script src="/js/header.js"></script>
 </body>

--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -32,7 +32,8 @@
     <a href="/prompt-history/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1" data-link="history">
       <span>Prompt History</span>
     </a>
-    <button id="signout-btn" type="button" class="sidebar-btn flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1">
+    <button id="signout-btn" data-action="signout"
+      class="w-full mt-4 px-3 py-2 rounded-lg bg-gray-200 text-gray-900 hover:bg-gray-300 transition">
       Sign Out
     </button>
     </div>

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -1,73 +1,40 @@
-// /docs/js/sidebar.js
-// Assumes the sidebar HTML may be injected dynamically.
-// We use event delegation so the handler works no matter when the button appears.
-
+// Requires Firebase Auth already initialized
 (function () {
-  async function doSignOut() {
-    try {
-      // Try Firebase v8 (namespaced)
-      if (window.firebase && typeof firebase.auth === 'function') {
+  function attachSignOut(el) {
+    if (!el || el.__wired) return;
+    el.__wired = true;
+    el.addEventListener('click', async () => {
+      try {
+        if (!window.firebase?.auth) throw new Error('Firebase Auth not loaded');
         await firebase.auth().signOut();
-      } else {
-        // Try Firebase v9 (modular) on global scope
-        const getAuth = window.getAuth || (window.firebase && window.firebase.getAuth);
-        const signOut = window.signOut || (window.firebase && window.firebase.signOut);
-        if (typeof getAuth === 'function' && typeof signOut === 'function') {
-          const auth = getAuth();
-          await signOut(auth);
-        } else {
-          throw new Error('Firebase Auth not initialized on page.');
-        }
+        window.location.href = '/login/';
+      } catch (e) {
+        console.error('Sign out failed:', e);
+        alert('Sign out failed. See console for details.');
       }
-      // Redirect after successful sign out
-      window.location.href = '/login/';
-    } catch (e) {
-      console.error('Sign out failed:', e);
-      alert('Sign out failed. Please try again.');
-    }
+    });
   }
 
-  // Event delegation: works even if #signout-btn is injected later
-  document.addEventListener('click', function (e) {
-    const btn = e.target && (e.target.id === 'signout-btn' ? e.target : e.target.closest && e.target.closest('#signout-btn'));
-    if (btn) {
-      e.preventDefault();
-      doSignOut();
-    }
-  });
+  function findAndWire() {
+    const btn = document.getElementById('signout-btn') ||
+                document.querySelector('[data-action="signout"]');
+    attachSignOut(btn);
+  }
 
-  // --- (Optional) Keep your active-link code below this line ---
-  // Active link highlight (preserve existing logic)
-  try {
-    const path = window.location.pathname.replace(/\/+$/, '/').toLowerCase();
-    const clearCls = (selector) => {
-      document.querySelectorAll(selector).forEach((el) => {
-        el.classList.remove('bg-gray-100', 'text-gray-900', 'font-semibold');
-      });
-      return (el) => el && el.classList.add('bg-gray-100', 'text-gray-900', 'font-semibold');
-    };
-    const setActive = clearCls('.sidebar-link, .sidebar-sublink');
-    // Map routes to data-link keys (adjust as needed)
-    const map = [
-      { rx: /^\/$/, key: 'home' },
-      { rx: /^\/ai-assistant-terraform\/?$/i, key: 'terraform', openAI: true },
-      { rx: /^\/ai-assistant-helm\/?$/i, key: 'helm', openAI: true },
-      { rx: /^\/ai-assistant-k8s\/?$/i, key: 'k8s', openAI: true },
-      { rx: /^\/ai-assistant-ansible\/?$/i, key: 'ansible', openAI: true },
-      { rx: /^\/ai-assistant-yaml\/?$/i, key: 'yaml', openAI: true },
-      { rx: /^\/ai-assistant-docker\/?$/i, key: 'docker', openAI: true },
-      { rx: /^\/prompt-history\/?$/i, key: 'history' },
-      { rx: /^\/profile\/?$/i, key: 'profile' },
-    ];
-    const hit = map.find(m => m.rx.test(path));
-    if (hit) {
-      const el = document.querySelector(`[data-link="${hit.key}"]`);
-      setActive(el);
-      // Ensure AI Assistants accordion opens if a child route is active
-      if (hit.openAI) {
-        const acc = document.getElementById('ai-assistants-accordion');
-        if (acc && !acc.open) acc.open = true;
-      }
-    }
-  } catch (_) {}
+  // Wire immediately if present
+  document.addEventListener('DOMContentLoaded', findAndWire);
+
+  // Also observe sidebar container for late-injected HTML
+  const sidebarCtn = document.getElementById('sidebar-container') || document.body;
+  const mo = new MutationObserver(() => findAndWire());
+  mo.observe(sidebarCtn, { childList: true, subtree: true });
+
+  // Highlight active link if the sidebar is present
+  function highlightActive() {
+    try {
+      const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
+      if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
+    } catch {}
+  }
+  document.addEventListener('DOMContentLoaded', highlightActive);
 })();


### PR DESCRIPTION
## Summary
- Make sidebar sign out button consistent via `signout-btn` and data-action
- Replace sidebar script with resilient sign-out listener and active link highlighting
- Refactor all AI assistant pages to reuse profile layout and async sidebar loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a964ed2624832fa6e02d15ddbd09c4