### PR TITLE
feat: add pricing link to navigation

### DIFF
--- a/docs/components/header.html
+++ b/docs/components/header.html
@@ -9,6 +9,7 @@
         <li><a href="/" data-nav="home" class="site-nav__link">Home</a></li>
         <li><a href="/product/" data-nav="product" class="site-nav__link">Product</a></li>
         <li><a href="/resources/" data-nav="resources" class="site-nav__link">Resources</a></li>
+        <li><a href="/pricing/" data-nav="pricing" class="site-nav__link">Pricing</a></li>
         <li>
           <a href="/login/" class="site-cta">
             Let’s build

--- a/docs/js/header.js
+++ b/docs/js/header.js
@@ -14,6 +14,7 @@
         { key: 'home', test: p => p === '/' || p === '' },
         { key: 'product', test: p => p.startsWith('/product') },
         { key: 'resources', test: p => p.startsWith('/resources') },
+        { key: 'pricing', test: p => p.startsWith('/pricing') },
       ];
       const match = map.find(m => m.test(path));
       if (match) {


### PR DESCRIPTION
## Summary
- add Pricing item in header navigation
- highlight Pricing link when on pricing page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9687ca104832f9eed525a282f836a