### PR TITLE
feat: make site header span full width

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,6 +1,9 @@
-body {
+html, body {
   margin: 0;
-  padding: 2rem;
+  padding: 0;
+}
+
+body {
   font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', sans-serif;
   background: #f9fafb;
   color: #374151;
@@ -176,7 +179,6 @@ a {
 @media (max-width: 600px) {
   body {
     font-size: 1rem;
-    padding: 1rem;
   }
   h1 {
     font-size: 1.75rem;
@@ -382,23 +384,25 @@ body.with-fixed-header {
   }
 }
 
-/* Reusable site header */
+/* Make header span full width of viewport */
 .site-header {
+  width: 100%;
   background: #F4F4F2;
   border-bottom: 1px solid #0D0E0C;
-  color: #0D0E0C;
-  text-align: left;
-  margin-bottom: 0;
+  margin: 0;         /* remove gaps */
+  padding: 0;        /* no forced spacing around */
+  box-sizing: border-box;
 }
 
+/* Let inner flex container auto-size */
 .site-header__inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 12px 16px;
+  width: 100%;
+  max-width: none;   /* remove fixed 1200px cap */
+  margin: 0;
+  padding: 12px 20px;  /* flexible padding only */
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
 }
 
 .site-header__logo {


### PR DESCRIPTION
## Summary
- ensure html and body have no default margins or padding
- allow site header and inner flex container to stretch full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a977a155f8832fb2b5e6a499b1290f