### PR TITLE
Make site header sticky and full-width

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,3 +1,4 @@
+/* Reset page chrome to remove gaps */
 html, body {
   margin: 0;
   padding: 0;
@@ -298,6 +299,11 @@ body.with-fixed-header {
   padding-top: var(--header-min-h);
 }
 */
+/* Give headings a comfortable scroll offset so they're not hidden under the sticky header */
+:target {
+  scroll-margin-top: 72px; /* ≈ header height; tweak if needed */
+}
+
 /* --- Prompt History layout helpers (no Tailwind @apply) --- */
 .history-item {
   background: #ffffff;
@@ -384,25 +390,29 @@ body.with-fixed-header {
   }
 }
 
-/* Make header span full width of viewport */
+/* Full-bleed, auto-height, sticky header */
 .site-header {
+  position: sticky;   /* keeps it visible while scrolling */
+  top: 0;
+  z-index: 1000;      /* above page content */
   width: 100%;
   background: #F4F4F2;
   border-bottom: 1px solid #0D0E0C;
-  margin: 0;         /* remove gaps */
-  padding: 0;        /* no forced spacing around */
+  margin: 0;
+  padding: 0;
   box-sizing: border-box;
 }
 
-/* Let inner flex container auto-size */
+/* Flexible inner layout (no fixed max-width) */
 .site-header__inner {
   width: 100%;
-  max-width: none;   /* remove fixed 1200px cap */
+  max-width: none;       /* remove 1200px cap */
   margin: 0;
-  padding: 12px 20px;  /* flexible padding only */
+  padding: 12px 20px;    /* controls visual height */
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 }
 
 .site-header__logo {
@@ -457,14 +467,6 @@ body.with-fixed-header {
 .site-cta:active {
   transform: translateY(1px);
 }
-
-/* Optional: make header sticky if desired
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-}
-*/
 
 /* Layout helpers */
 .container {

--- a/docs/js/header.js
+++ b/docs/js/header.js
@@ -22,24 +22,6 @@
         if (active) active.classList.add('is-active');
       }
 
-      // Ensure page content doesn’t slide under fixed header (if fixed later)
-      const header = mount.querySelector('.site-header');
-      if (header) {
-        const next = mount.nextElementSibling;
-        if (next && !next.dataset.headerAdjusted) {
-          const rect = header.getBoundingClientRect();
-          const h = Math.ceil(rect.height);
-          if (h > 0) {
-            const style = window.getComputedStyle(header);
-            const position = style.position;
-            if (position === 'fixed' || position === 'sticky') {
-              next.style.scrollMarginTop = h + 'px';
-              next.style.paddingTop = 'clamp(8px, 2vw, 16px)';
-              next.dataset.headerAdjusted = 'true';
-            }
-          }
-        }
-      }
     })
     .catch(err => {
       console.error('Failed to load header:', err);


### PR DESCRIPTION
## Summary
- Make site header sticky, full-bleed, and flexible in height
- Ensure anchor targets aren't obscured by sticky header
- Remove JavaScript padding logic for fixed header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a97af71e4c832fbe787bc45de6d689