### PR TITLE
refactor: harden sidebar sign out

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -57,7 +57,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -82,7 +82,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -93,11 +93,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -111,6 +106,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -57,7 +57,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -82,7 +82,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -93,11 +93,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -111,6 +106,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -57,7 +57,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -82,7 +82,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -93,11 +93,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -111,6 +106,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -57,7 +57,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -82,7 +82,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -93,11 +93,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -111,6 +106,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -56,7 +56,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -81,7 +81,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -92,11 +92,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -110,6 +105,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -57,7 +57,7 @@
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/ai-assistant.js"></script>
 
-  <!-- Firebase + page scripts -->
+  <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
@@ -82,7 +82,7 @@
       setTimeout(() => { el.classList.add('hidden'); }, 2600);
     }
 
-    // Load sidebar HTML, highlight, and load sidebar.js AFTER injection
+    // Load sidebar HTML and highlight
     (async function loadSidebar(){
       try {
         const res = await fetch('/components/sidebar.html', { cache:'no-store' });
@@ -93,11 +93,6 @@
         // highlight here (fallback; sidebar.js also does it)
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
-
-        // important: load the sidebar behavior after HTML is in DOM
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -111,6 +106,8 @@
       // If you require verified emails here, add the check similar to /profile
     });
   </script>
+  <!-- Shared sidebar behavior (event-delegated sign out, highlight) -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>

--- a/docs/components/sidebar.html
+++ b/docs/components/sidebar.html
@@ -32,6 +32,7 @@
     <a href="/prompt-history/" class="sidebar-link flex items-center gap-2 px-3 py-2 rounded hover:bg-gray-100 mt-1" data-link="history">
       <span>Prompt History</span>
     </a>
+    <!-- Canonical Sign Out button -->
     <button id="signout-btn" data-action="signout"
       class="w-full mt-4 px-3 py-2 rounded-lg bg-gray-200 text-gray-900 hover:bg-gray-300 transition">
       Sign Out

--- a/docs/js/sidebar.js
+++ b/docs/js/sidebar.js
@@ -1,40 +1,41 @@
-// Requires Firebase Auth already initialized
 (function () {
-  function attachSignOut(el) {
-    if (!el || el.__wired) return;
-    el.__wired = true;
-    el.addEventListener('click', async () => {
-      try {
-        if (!window.firebase?.auth) throw new Error('Firebase Auth not loaded');
-        await firebase.auth().signOut();
-        window.location.href = '/login/';
-      } catch (e) {
-        console.error('Sign out failed:', e);
-        alert('Sign out failed. See console for details.');
-      }
-    });
-  }
+  // --- Debug helper (optional): comment out if noisy
+  const dbg = (...args) => console.debug('[sidebar]', ...args);
 
-  function findAndWire() {
-    const btn = document.getElementById('signout-btn') ||
-                document.querySelector('[data-action="signout"]');
-    attachSignOut(btn);
-  }
-
-  // Wire immediately if present
-  document.addEventListener('DOMContentLoaded', findAndWire);
-
-  // Also observe sidebar container for late-injected HTML
-  const sidebarCtn = document.getElementById('sidebar-container') || document.body;
-  const mo = new MutationObserver(() => findAndWire());
-  mo.observe(sidebarCtn, { childList: true, subtree: true });
-
-  // Highlight active link if the sidebar is present
-  function highlightActive() {
+  function highlightActiveLink() {
     try {
       const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
       if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
     } catch {}
   }
-  document.addEventListener('DOMContentLoaded', highlightActive);
+
+  // 1) Event delegation: works for late-injected HTML too
+  document.addEventListener('click', async (e) => {
+    const el = e.target.closest('#signout-btn,[data-action="signout"]');
+    if (!el) return;
+    e.preventDefault();
+    try {
+      if (!window.firebase?.auth) throw new Error('Firebase Auth not loaded');
+      // Prevent double-clicks
+      if (el.dataset.busy === '1') return;
+      el.dataset.busy = '1';
+      dbg('Signing out…');
+      await firebase.auth().signOut();
+      window.location.href = '/login/';
+    } catch (err) {
+      console.error('Sign out failed:', err);
+      // Minimal fallback UX
+      alert('Sign out failed. See console for details.');
+    } finally {
+      el.dataset.busy = '0';
+    }
+  });
+
+  // 2) Highlight active link when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', highlightActiveLink);
+  } else {
+    highlightActiveLink();
+  }
 })();
+

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -89,7 +89,7 @@
   <!-- Footer -->
   <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
 
-  <!-- Firebase + page script -->
+  <!-- Firebase must be first -->
   <script src="/js/firebase-init.js"></script>
   <script>
     // ---------------- Toast helpers ----------------
@@ -121,10 +121,7 @@
         const active = document.querySelector(`#sidebar-container a[href="${location.pathname}"]`);
         if (active) active.classList.add('bg-gray-100','text-gray-900','font-semibold');
 
-        // load sidebar script for sign-out and dynamic behavior
-        const s = document.createElement('script');
-        s.src = '/js/sidebar.js';
-        document.body.appendChild(s);
+        // sidebar.js is loaded globally after this block
       } catch(e) {
         console.error('Sidebar load failed', e);
       }
@@ -281,6 +278,8 @@
       if (status === 'cancel')  showToast('Billing was canceled.', 'warn');
     })();
   </script>
+  <!-- Load shared sidebar behavior last -->
+  <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- consolidate sign-out button in sidebar component
- delegate sidebar sign-out handling and link highlight to resilient script
- standardize firebase and sidebar script order on profile and AI assistant pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97e22dacc832fb12250a11d5917c1