### PR TITLE
Implement inactivity auto sign-out

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -59,6 +59,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -101,6 +102,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -59,6 +59,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -101,6 +102,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -59,6 +59,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -101,6 +102,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -59,6 +59,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -101,6 +102,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -58,6 +58,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -100,6 +101,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -59,6 +59,7 @@
 
   <!-- Firebase must load before sidebar.js -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // Toast (optional but nice to keep consistent with /profile)
     function showToast(msg, type = 'info') {
@@ -101,6 +102,7 @@
     // Auth guard for assistant pages
     firebase.auth().onAuthStateChanged((user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
       }
       // If you require verified emails here, add the check similar to /profile

--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -103,6 +103,7 @@ onAuthStateChanged(auth, async (user) => {
                        path === '/profile/';
 
   if (!user) {
+    if (window.__autoLogout) return;
     if (requiresAuth) {
       const cont = encodeURIComponent(path + window.location.search);
       window.location.replace(`/login/?continue=${cont}`);

--- a/docs/js/inactivity-timeout.js
+++ b/docs/js/inactivity-timeout.js
@@ -1,0 +1,33 @@
+(function() {
+  const TIMEOUT = 30 * 60 * 1000; // 30 minutes
+  const events = ['mousemove', 'keydown', 'click', 'scroll', 'touchstart'];
+  let timer;
+
+  function resetTimer() {
+    clearTimeout(timer);
+    timer = setTimeout(handleInactivity, TIMEOUT);
+  }
+
+  async function handleInactivity() {
+    try {
+      window.__autoLogout = true;
+      events.forEach(evt => window.removeEventListener(evt, resetTimer));
+      await firebase.auth().signOut();
+      showToast();
+    } catch (e) {
+      console.error('Auto sign-out failed', e);
+    }
+  }
+
+  function showToast() {
+    const toast = document.createElement('div');
+    toast.textContent = "You've been signed out due to inactivity.";
+    toast.className = 'fixed bottom-4 right-4 z-50 px-4 py-2 rounded shadow bg-gray-800 opacity-90 text-white font-semibold text-sm transition-opacity';
+    document.body.appendChild(toast);
+    setTimeout(() => { toast.style.opacity = '0'; }, 3000);
+    setTimeout(() => { toast.remove(); window.location.href = '/login/'; }, 3500);
+  }
+
+  events.forEach(evt => window.addEventListener(evt, resetTimer, { passive: true }));
+  resetTimer();
+})();

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -91,6 +91,7 @@
 
   <!-- Firebase must be first -->
   <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
   <script>
     // ---------------- Toast helpers ----------------
     function showToast(msg, type = 'info') {
@@ -131,6 +132,7 @@
     let currentUser = null;
     firebase.auth().onAuthStateChanged(async (user) => {
       if (!user) {
+        if (window.__autoLogout) return;
         window.location.href = '/login/';
         return;
       }

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -33,6 +33,8 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script type="module" src="/js/prompt-history.js"></script>
+  <script src="/js/firebase-init.js"></script>
+  <script src="/js/inactivity-timeout.js"></script>
     <script>
     // Load sidebar include
     (async function() {


### PR DESCRIPTION
## Summary
- auto sign-out users after 30 minutes of inactivity with toast and redirect
- respect auto-logout flag in auth checks
- include inactivity timeout script across protected pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab345c3d4c832f823dd7491f96eb0e