### PR TITLE
Update header logo and favicon

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — About</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant for Ansible</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant for Docker</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant for Helm</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant for K8s</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant - Devopsia</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -6,7 +6,8 @@
   <title>AI Assistant for YAML</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/behind-the-build/index.html
+++ b/docs/behind-the-build/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Behind the Build</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/components/header.html
+++ b/docs/components/header.html
@@ -1,7 +1,8 @@
 <header class="site-header" role="banner">
   <div class="site-header__inner">
-    <a href="/" class="site-header__logo-link" aria-label="Devopsia Home">
-      <img src="/assets/Lynx Logo Design.png" alt="Devopsia" class="site-header__logo">
+    <a href="/" class="flex items-center space-x-2">
+      <img src="/assets/logo.png" alt="Devopsia Logo" class="h-8 w-auto">
+      <span class="font-ubuntu text-gray-800 ml-2">DevopsIA</span>
     </a>
 
     <nav class="site-nav" aria-label="Primary">

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Contact</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -21,6 +21,11 @@ body {
   font-weight: 400;
 }
 
+.font-ubuntu {
+  font-family: 'Ubuntu Sans', sans-serif;
+  font-weight: 200;
+}
+
 .container {
   max-width: 960px;
   margin: 0 auto;

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Your AI DevOps Engineer</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/kits/index.html
+++ b/docs/kits/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Kits</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Login</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Pricing</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Privacy Policy</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Devopsia — Product</title>
   <link rel="stylesheet" href="/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
 </head>
 <body>
   <div id="top-banner"></div>

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -6,6 +6,8 @@
   <title>Devopsia — Profile</title>
   <link rel="stylesheet" href="/css/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -7,7 +7,8 @@
   <link rel="stylesheet" href="/css/base.css">
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Devopsia — Resources</title>
   <link rel="stylesheet" href="/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
 </head>
 <body>
   <div id="top-banner"></div>

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Sign Up</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -6,7 +6,8 @@
   <title>Devopsia — Terms of Service</title>
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/flame-icon.svg" type="image/svg+xml">
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
+  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Import Ubuntu Sans ExtraLight font and use new Lynx favicon across site
- Make DevopsIA logo and name a single home link in the header
- Add font-ubuntu utility class for lightweight branding text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac37b02c48832f9ef911f1a5670771