### PR TITLE
Load footer component dynamically across site

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -20,10 +20,11 @@
       <p>This page is under construction.</p>
     </div>
   </main>
-  <footer>© 2025 Devopsia</footer>
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -94,8 +94,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -159,6 +157,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -94,8 +94,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -159,6 +157,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -94,8 +94,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -159,6 +157,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -94,8 +94,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -159,6 +157,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -93,8 +93,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -158,6 +156,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -94,8 +94,6 @@
     </main>
   </div>
 
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
-
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
@@ -159,6 +157,8 @@
     window.API_BASE = window.API_BASE || 'https://api.devopsia.co';
   </script>
   <script src="/js/file-processor.js" defer></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
 

--- a/docs/behind-the-build/index.html
+++ b/docs/behind-the-build/index.html
@@ -43,10 +43,10 @@
       <p class="text-gray-700">Devopsia was created by engineers who wanted better tools — and fewer tabs open. If you're building serious infrastructure and want smarter help, you're in the right place.</p>
     </section>
   </main>
-
-  <footer class="text-center py-4">© 2025 Devopsia</footer>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/components/footer.html
+++ b/docs/components/footer.html
@@ -1,4 +1,4 @@
-<footer class="w-full border-t bg-white/90 backdrop-blur py-6 px-4">
+<footer data-autoload class="w-full border-t bg-white/90 backdrop-blur py-6 px-4">
   <div class="max-w-6xl mx-auto flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
     <div class="flex flex-col items-center gap-2 text-sm text-gray-600 md:flex-row md:gap-4">
       <span>© 2025 Devopsia</span>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -20,10 +20,11 @@
       <p>This page is under construction.</p>
     </div>
   </main>
-  <footer>© 2025 Devopsia</footer>
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,8 +50,6 @@
     </div>
   </section>
 
-  <footer class="mt-auto text-center py-4">© 2025 Devopsia</footer>
-
   <script type="module">
     import { initializeApp, getApps } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js';
     import { getAuth, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
@@ -108,5 +106,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/js/footer-loader.js
+++ b/docs/js/footer-loader.js
@@ -1,0 +1,39 @@
+(function () {
+  async function loadFooter() {
+    try {
+      // Prefer a placeholder container if present; otherwise create one
+      let host = document.getElementById('footer-container');
+      if (!host) {
+        host = document.createElement('div');
+        host.id = 'footer-container';
+        document.body.appendChild(host);
+      }
+
+      // Use an absolute path so subpages like /ai-assistant-terraform/ work
+      const url = '/components/footer.html';
+
+      // Cache-buster so updates show up immediately on GH Pages
+      const res = await fetch(`${url}?v=${Date.now()}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Failed to fetch footer: ${res.status}`);
+
+      const html = await res.text();
+
+      const existing = document.querySelector('footer[data-autoload]');
+      if (existing) existing.remove();
+      host.innerHTML = html;
+
+      // If the footer relies on icons or scripts, rehydrate here (not needed for inline SVGs)
+      // Example (if we later switch to Lucide): window.lucide?.createIcons?.();
+
+    } catch (err) {
+      console.error('[Footer] load error:', err);
+    }
+  }
+
+  // Load when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadFooter);
+  } else {
+    loadFooter();
+  }
+})();

--- a/docs/kits/index.html
+++ b/docs/kits/index.html
@@ -20,10 +20,11 @@
       <p>This page is under construction.</p>
     </div>
   </main>
-  <footer>© 2025 Devopsia</footer>
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -39,7 +39,6 @@
       </p>
     </div>
   </main>
-  <footer class="text-center py-4">© 2025 Devopsia</footer>
   <div id="resend-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
     <div class="bg-white p-6 rounded shadow w-full max-w-sm" role="dialog" aria-modal="true">
       <h2 class="text-xl font-bold mb-4">Resend verification</h2>
@@ -58,5 +57,7 @@
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -74,8 +74,6 @@
     </div>
   </main>
 
-  <footer class="text-center py-4">© 2025 Devopsia</footer>
-
   <script>
     const btnMonthly = document.getElementById('btnMonthly');
     const btnAnnual = document.getElementById('btnAnnual');
@@ -193,5 +191,7 @@
     };
   </script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -81,10 +81,11 @@
       <p><strong>Thanks for trusting Devopsia — your secrets are safe in our vault.</strong> 🔐</p>
     </div>
   </main>
-  <footer>© 2025 Devopsia</footer>
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -21,5 +21,7 @@
   </main>
 
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -89,7 +89,6 @@
   </div>
 
   <!-- Footer -->
-  <footer class="mt-10 py-8 text-center text-xs text-gray-500">© 2025 Devopsia</footer>
 
   <!-- Firebase must be first -->
   <script src="/js/firebase-init.js"></script>
@@ -285,5 +284,7 @@
   <!-- Load shared sidebar behavior last -->
   <script src="/js/sidebar.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -50,5 +50,7 @@
     })();
   </script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -21,5 +21,7 @@
   </main>
 
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -124,10 +124,11 @@
       <p class="mt-4 text-center text-sm">Already have an account? <a href="/login/" class="text-orange-600 hover:underline">Log in</a></p>
     </div>
   </main>
-  <footer class="text-center py-4">© 2025 Devopsia</footer>
 
   <script type="module" src="/js/auth.js"></script>
 
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -68,10 +68,11 @@
       <p><strong>Thanks for choosing Devopsia — now go ship something great.</strong> 🚀</p>
     </div>
   </main>
-  <footer>© 2025 Devopsia</footer>
   </div>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>
   <script src="/js/header.js"></script>
+  <div id="footer-container"></div>
+  <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `footer-loader.js` to inject footer on page load with cache-busting
- mark footer component for autoload and use absolute asset links
- replace static footers with loader placeholder on all pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4d1daecc832fbe120682a865251e