### PR TITLE
feat: replace prompt mode buttons with dropdown

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Ansible playbook question..."></textarea>
@@ -94,6 +158,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Docker question..."></textarea>
@@ -94,6 +158,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your Helm question..."></textarea>
@@ -94,6 +158,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your K8s question..."></textarea>
@@ -94,6 +158,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Type your DevOps question..."></textarea>
@@ -93,6 +157,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>[x-cloak]{display:none !important;}</style>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
@@ -35,12 +36,75 @@
               </div>
             </div>
           </div>
-          <div class="mode-toolbar mb-4">
-            <div id="prompt-mode-buttons">
-              <button class="btn-mode" data-mode="default">Default</button>
-              <button class="btn-mode" data-mode="optimized">Optimized</button>
-              <button class="btn-mode" data-mode="secure">Secure</button>
+          <!-- Prompt Mode Dropdown -->
+          <div
+            x-data="promptModeDropdown()"
+            x-init="init()"
+            class="relative inline-block text-left mb-4"
+          >
+            <!-- Trigger -->
+            <button
+              @click="toggle()"
+              @keydown.arrow-down.prevent="openAndMove(1)"
+              @keydown.arrow-up.prevent="openAndMove(-1)"
+              @keydown.enter.prevent="openAndSelect()"
+              @keydown.space.prevent="toggle()"
+              @keydown.escape.prevent.stop="open = false"
+              :aria-expanded="open"
+              aria-haspopup="listbox"
+              class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium bg-white hover:bg-gray-50 border-gray-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <span x-html="iconFor(value)" aria-hidden="true"></span>
+              <span class="text-gray-700">Mode:</span>
+              <span class="text-gray-900" x-text="labelFor(value)"></span>
+              <svg class="w-4 h-4 text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+
+            <!-- Menu -->
+            <div
+              x-cloak
+              x-show="open"
+              @click.outside="open = false"
+              @keydown.escape.prevent.stop="open = false"
+              class="absolute z-20 mt-2 w-64 rounded-xl border border-gray-200 bg-white shadow-xl p-2"
+              role="listbox"
+              :aria-activedescendant="'mode-opt-' + activeIndex"
+            >
+              <template x-for="(opt, idx) in options" :key="opt.value">
+                <button
+                  type="button"
+                  @click="select(idx)"
+                  @mousemove="activeIndex = idx"
+                  @keydown.arrow-down.prevent="move(1)"
+                  @keydown.arrow-up.prevent="move(-1)"
+                  @keydown.enter.prevent="select(activeIndex)"
+                  @keydown.space.prevent="select(activeIndex)"
+                  :id="'mode-opt-' + idx"
+                  role="option"
+                  :aria-selected="value === opt.value"
+                  class="w-full flex items-start gap-3 rounded-lg px-3 py-2 text-left focus:outline-none"
+                  :class="activeIndex === idx ? 'bg-gray-50' : 'hover:bg-gray-50'"
+                  tabindex="-1"
+                >
+                  <div class="mt-0.5 shrink-0" x-html="iconFor(opt.value)" aria-hidden="true"></div>
+
+                  <div class="min-w-0">
+                    <div class="text-sm font-medium text-gray-900" x-text="opt.label"></div>
+                    <div class="text-xs text-gray-500" x-text="opt.desc"></div>
+                  </div>
+
+                  <div class="ml-auto flex items-center gap-2">
+                    <span class="text-[10px] text-gray-400 uppercase tracking-wide" x-text="opt.badge"></span>
+                    <div class="w-2.5 h-2.5 rounded-full" :class="value === opt.value ? 'bg-blue-600' : 'bg-gray-300'"></div>
+                  </div>
+                </button>
+              </template>
             </div>
+
+            <!-- Hidden input for existing code -->
+            <input type="hidden" id="prompt-mode" name="promptMode" x-model="value">
           </div>
         </div>
         <textarea id="promptInput" class="w-full p-4 border rounded" rows="5" placeholder="Describe your YAML question..."></textarea>
@@ -94,6 +158,7 @@
     </main>
   </div>
 
+  <script src="/js/prompt-mode.js"></script>
   <script src="/js/ui-common.js"></script>
   <script type="module" src="/js/firebase.js"></script>
   <script type="module" src="/js/auth.js"></script>

--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -3,11 +3,14 @@ import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/f
 import { doc, getDoc, setDoc, collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
 
 let userPlan = 'free';
-let currentMode = 'default';
+let currentMode = 'secure';
 
-window.onModeChange = (mode) => {
-  currentMode = mode;
-};
+document.addEventListener('promptMode:change', (e) => {
+  currentMode = e.detail.mode;
+});
+document.addEventListener('DOMContentLoaded', () => {
+  document.dispatchEvent(new window.Event('promptMode:get'));
+});
 
 function showToast(message) {
   const toast = document.createElement('div');
@@ -59,19 +62,6 @@ export function promptComponent() {
         } catch (err) {
           console.error('Failed to load user settings', err);
         }
-        const secureBtn = document.querySelector('#prompt-mode-buttons .btn-mode[data-mode="secure"]');
-        if (secureBtn && !this.isPro) {
-          secureBtn.disabled = true;
-          secureBtn.classList.add('opacity-50', 'cursor-not-allowed');
-        }
-        const self = this;
-        window.onModeChange = function(mode) {
-          if (mode === 'secure' && !self.isPro) {
-            showToast('Secure mode is available on Pro only');
-            return;
-          }
-          currentMode = mode;
-        };
       });
     }
   };

--- a/docs/js/prompt-mode.js
+++ b/docs/js/prompt-mode.js
@@ -1,0 +1,72 @@
+function promptModeDropdown() {
+  return {
+    open: false,
+    value: 'secure',
+    activeIndex: 0,
+    options: [
+      { value: 'secure',    label: 'Secure',    badge: 'Hardened', desc: 'Defense-in-depth prompts, injection-resistant' },
+      { value: 'optimized', label: 'Optimized', badge: 'Balanced',  desc: 'Best quality vs. speed for most tasks' },
+      { value: 'fast',      label: 'Fast',      badge: 'Lite',      desc: 'Lower cost & latency, concise outputs' },
+    ],
+    init() {
+      const saved = localStorage.getItem('devopsia:promptMode');
+      if (saved && this.options.some(o => o.value === saved)) this.value = saved;
+      this.emit();
+      this.activeIndex = this.options.findIndex(o => o.value === this.value) || 0;
+      this.$watch('open', (v) => {
+        if (v) queueMicrotask(() => {
+          const el = document.getElementById('mode-opt-' + this.activeIndex);
+          el?.focus();
+        });
+      });
+      document.addEventListener('promptMode:get', () => this.emit());
+    },
+    toggle() { this.open = !this.open; },
+    openAndMove(dir) {
+      if (!this.open) { this.open = true; return; }
+      this.move(dir);
+    },
+    openAndSelect() {
+      if (!this.open) { this.open = true; return; }
+      this.select(this.activeIndex);
+    },
+    move(delta) {
+      const max = this.options.length - 1;
+      let next = this.activeIndex + delta;
+      if (next < 0) next = max;
+      if (next > max) next = 0;
+      this.activeIndex = next;
+      queueMicrotask(() => document.getElementById('mode-opt-' + this.activeIndex)?.focus());
+    },
+    select(idx) {
+      const opt = this.options[idx];
+      if (!opt) return;
+      this.value = opt.value;
+      localStorage.setItem('devopsia:promptMode', this.value);
+      this.emit();
+      this.open = false;
+    },
+    labelFor(v) {
+      const o = this.options.find(o => o.value === v);
+      return o ? o.label : 'Mode';
+    },
+    emit() {
+      const input = document.getElementById('prompt-mode');
+      if (input) input.value = this.value;
+      document.dispatchEvent(new CustomEvent('promptMode:change', { detail: { mode: this.value } }));
+    },
+    iconFor(v) {
+      const base = 'class="w-4 h-4 text-gray-600" fill="currentColor" viewBox="0 0 24 24"';
+      switch (v) {
+        case 'secure':
+          return `<svg ${base} aria-hidden="true"><path d="M12 2l7 4v6c0 5-3.4 9.7-7 10-3.6-.3-7-5-7-10V6l7-4zm0 6a3 3 0 013 3v2a3 3 0 01-6 0v-2a3 3 0 013-3z"/></svg>`;
+        case 'optimized':
+          return `<svg ${base} aria-hidden="true"><path d="M3 12h6l3-9 3 18 3-9h3"/><circle cx="3" cy="12" r="1.5"/><circle cx="21" cy="12" r="1.5"/></svg>`;
+        case 'fast':
+          return `<svg ${base} aria-hidden="true"><path d="M2 13h10l-4 8 14-12H10l4-8L2 13z"/></svg>`;
+        default:
+          return `<svg ${base} aria-hidden="true"><circle cx="12" cy="12" r="6"/></svg>`;
+      }
+    }
+  }
+}

--- a/tests/ai-assistant-ui.test.js
+++ b/tests/ai-assistant-ui.test.js
@@ -1,28 +1,25 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {JSDOM} from 'jsdom';
+import { JSDOM } from 'jsdom';
 import fs from 'fs';
 import vm from 'vm';
 
-// helper to load ui-common.js into a window
-function loadUiCommon(window){
-  const code = fs.readFileSync('./docs/js/ui-common.js', 'utf8');
-  const context = vm.createContext({ window, document: window.document, localStorage: window.localStorage, console });
-  const script = new vm.Script(code, { filename: 'ui-common.js' });
-  script.runInContext(context);
-  return context.window.DevopsiaUI;
-}
-
-// helper to load ai-assistant.js with stubbed firebase
-function loadAiAssistant(window, {plan='free'} = {}){
+function loadAi(window, { plan = 'free' } = {}) {
   const raw = fs.readFileSync('./docs/js/ai-assistant.js', 'utf8');
-    const sanitized = raw
-      .replace(/import[^;]+;\n/g, '')
-      .replace('export function promptComponent', 'function promptComponent')
-      .replace('setTimeout(() => toast.remove(), 3000);', '');
-    const code = sanitized + '\nwindow.__getCurrentMode = () => currentMode;\n';
-    const context = vm.createContext({ window, document: window.document, localStorage: window.localStorage, console });
-  // stub firebase and firestore helpers
+  const sanitized = raw
+    .replace(/import[^;]+;\n/g, '')
+    .replace('export function promptComponent', 'function promptComponent');
+  const code = sanitized + '\nwindow.__getCurrentMode = () => currentMode;\n';
+  const context = vm.createContext({
+    window,
+    document: window.document,
+    localStorage: window.localStorage,
+    console,
+    fetch: async () => {
+      window.__fetchCalled = true;
+      return { ok: true, json: async () => ({ output: '' }) };
+    }
+  });
   context.auth = {};
   context.db = {};
   context.onAuthStateChanged = (auth, cb) => cb({ uid: 'u', emailVerified: true });
@@ -34,88 +31,34 @@ function loadAiAssistant(window, {plan='free'} = {}){
   context.serverTimestamp = () => 0;
   const script = new vm.Script(code, { filename: 'ai-assistant.js' });
   script.runInContext(context);
-  return { promptComponent: context.promptComponent, context };
+  return { context, window };
 }
 
-function createDom(path, {withExport=true} = {}){
-  const exportBtn = withExport ? '<button id="export-json-btn" class="inline-flex px-4 py-2 bg-blue-500 text-white hover:bg-blue-600">Export JSON</button>' : '';
-  const html = `${exportBtn}<div class="mode-toolbar mb-4"><div id="prompt-mode-buttons"><button class="btn-mode" data-mode="default">Default</button><button class="btn-mode" data-mode="optimized">Optimized</button><button class="btn-mode" data-mode="secure">Secure</button></div></div><button id="runPrompt"></button><div id="result"></div>`;
-  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { url: `https://example.com/${path}/`});
-  return dom;
-}
-
-const assistants = ['terraform','helm','k8s','yaml','ansible','docker'];
-
-test('prompt mode persists across reloads for each assistant page', () => {
-  for (const key of assistants){
-    const dom1 = createDom(`ai-assistant-${key}`, {withExport:false});
-    const {window} = dom1;
-    const ui = loadUiCommon(window);
-    ui.initPromptModeControls();
-    const optBtn = window.document.querySelector('.btn-mode[data-mode="optimized"]');
-    optBtn.click();
-    const storageKey = `devopsia.promptMode.${key}`;
-    const saved = window.localStorage.getItem(storageKey);
-    // simulate reload
-    const dom2 = createDom(`ai-assistant-${key}`, {withExport:false});
-    dom2.window.localStorage.setItem(storageKey, saved);
-    const ui2 = loadUiCommon(dom2.window);
-    ui2.initPromptModeControls();
-    const active = dom2.window.document.querySelector('.btn-mode.bg-green-500');
-    assert.ok(active, 'active button should be highlighted');
-    assert.equal(active.dataset.mode, 'optimized');
-  }
-});
-
-test('secure button disabled for non-pro users', async () => {
-  const dom = createDom('ai-assistant-terraform');
-  const {window} = dom;
-  const ui = loadUiCommon(window);
-  ui.initPromptModeControls();
-  const {promptComponent} = loadAiAssistant(window, {plan:'free'});
-  const comp = promptComponent();
-  await comp.init();
-  const secureBtn = window.document.querySelector('.btn-mode[data-mode="secure"]');
-  assert.ok(secureBtn.disabled);
-  assert.ok(secureBtn.classList.contains('opacity-50'));
-});
-
-test('non-Pro users cannot activate secure mode and receive toast', async () => {
-  const dom = createDom('ai-assistant-terraform');
-  const {window} = dom;
-  const ui = loadUiCommon(window);
-  ui.initPromptModeControls();
-  const {promptComponent, context} = loadAiAssistant(window, {plan:'free'});
-  const comp = promptComponent();
-  await comp.init();
-  // attempt to activate secure mode programmatically within VM context
-  vm.runInContext('window.onModeChange("secure")', context);
-  const toast = Array.from(window.document.querySelectorAll('div')).find(d => d.textContent.includes('Secure mode is available on Pro only'));
-  assert.ok(toast, 'toast should appear');
-  assert.equal(window.__getCurrentMode(), 'default');
-});
-
-test('mode buttons adopt export button styles', () => {
-  const dom = createDom('ai-assistant-terraform');
-  const {window} = dom;
-  const ui = loadUiCommon(window);
-  ui.initPromptModeControls();
-  const exportClass = window.document.getElementById('export-json-btn').className;
-  const exportClasses = exportClass.split(/\s+/).filter(Boolean);
-  const buttons = window.document.querySelectorAll('#prompt-mode-buttons .btn-mode');
-  buttons.forEach(btn => {
-    assert.equal(btn.classList.contains('btn-mode'), true);
-    assert.equal(btn.classList.contains('min-w-[140px]'), true);
-    exportClasses.forEach(cls => {
-      if (cls.startsWith('bg-') || cls.startsWith('hover:bg-')) return;
-      assert.equal(btn.classList.contains(cls), true);
-    });
+test('promptMode change event updates current mode', () => {
+  const dom = new JSDOM('<button id="runPrompt"></button><textarea id="promptInput"></textarea><div id="result"></div>', {
+    url: 'https://example.com/ai-assistant-terraform/'
   });
-  // non-active buttons should retain base blue styles
-  ['optimized','secure'].forEach(mode => {
-    const btn = window.document.querySelector(`.btn-mode[data-mode="${mode}"]`);
-    ['bg-blue-500','hover:bg-blue-600'].forEach(cls => assert.equal(btn.classList.contains(cls), true));
+  const { window } = dom;
+  loadAi(window);
+  window.document.dispatchEvent(
+    new window.CustomEvent('promptMode:change', { detail: { mode: 'fast' } })
+  );
+  assert.equal(window.__getCurrentMode(), 'fast');
+});
+
+test('runPrompt blocks secure mode for free plan', async () => {
+  const dom = new JSDOM('<button id="runPrompt"></button><textarea id="promptInput"></textarea><div id="result"></div>', {
+    url: 'https://example.com/ai-assistant-terraform/'
   });
-  const group = window.document.querySelector('.mode-toolbar');
-  ['flex','flex-wrap','gap-2','items-center'].forEach(cls => assert.equal(group.classList.contains(cls), true));
+  const { window } = dom;
+  const { context } = loadAi(window, { plan: 'free' });
+  window.document.dispatchEvent(
+    new window.CustomEvent('promptMode:change', { detail: { mode: 'secure' } })
+  );
+  context.showToast = (msg) => {
+    window.__toast = msg;
+  };
+  await window.document.getElementById('runPrompt').click();
+  assert.ok(window.__toast && window.__toast.includes('Secure mode is available'));
+  assert.ok(!window.__fetchCalled);
 });


### PR DESCRIPTION
## Summary
- replace prompt mode buttons across assistant pages with accessible dropdown
- add shared Alpine component for prompt mode
- listen for `promptMode:change` events in ai-assistant logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5442525c832fae765043966da4e5