### PR TITLE
feat(home): add responsive lynx illustrations next to hero text blocks

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -494,3 +494,34 @@ body.with-fixed-header {
 #file-processor textarea {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
+
+/* Responsive hero images (works with or without Tailwind) */
+.hero-img {
+  width: 100%;
+  height: auto;
+  max-width: 520px;     /* cap image width on large screens */
+  display: block;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.12);
+  object-fit: contain;  /* preserve full illustration */
+}
+
+/* Optional: ensure sections breathe on small screens */
+@media (max-width: 767px) {
+  section { padding-top: 2rem; padding-bottom: 2rem; }
+}
+
+/* Primary button (if not already defined) */
+.btn-primary {
+  background: linear-gradient(90deg, #1f7ae0, #7aa7ff);
+  color: #fff;
+  font-weight: 600;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  display: inline-block;
+  text-decoration: none;
+  transition: transform 0.06s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 24px rgba(31, 122, 224, 0.25);
+}
+.btn-primary:hover { transform: translateY(-1px); }
+.btn-primary:active { transform: translateY(0); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,27 +26,88 @@
     </div>
   </div>
 
-  <section class="container mx-auto py-12 grid md:grid-cols-2 gap-8 items-center">
-    <div>
-      <h2 class="text-3xl font-extrabold mb-4">Launch infrastructure in seconds</h2>
-      <p class="mb-4">Spin up CI/CD pipelines, container clusters, and monitoring with a single prompt.<br>No YAML nightmares, no copy-paste from StackOverflow. Just results.</p>
-      <a href="#" class="start-button bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 px-6 rounded shadow inline-block">Start building</a>
+  <section class="max-w-6xl mx-auto px-4 py-12">
+    <div class="grid items-center gap-8 md:grid-cols-2">
+      <!-- Text (left) -->
+      <div>
+        <h1 class="text-3xl md:text-4xl font-semibold leading-tight">
+          Launch infrastructure in seconds
+        </h1>
+        <p class="mt-4 text-gray-700">
+          Spin up CI/CD pipelines, container clusters, and monitoring with a single prompt.<br>
+          No YAML nightmares, no copy-paste from StackOverflow. Just results.
+        </p>
+        <a href="/ai-assistant-terraform/" class="inline-block mt-6 btn-primary">Start building</a>
+      </div>
+
+      <!-- Image (right) -->
+      <div class="flex justify-center">
+        <img
+          src="/assets/Lynx_drawing_1.png"
+          alt="Lynx illustration representing fast infra launch"
+          class="hero-img"
+          width="1200" height="1200"
+          decoding="async"
+          fetchpriority="high"
+          sizes="(min-width: 1024px) 520px, (min-width: 768px) 50vw, 90vw"
+        >
+      </div>
     </div>
   </section>
 
-  <section class="container mx-auto py-12 grid md:grid-cols-2 gap-8 items-center">
-    <div class="md:order-2">
-      <h2 class="text-3xl font-extrabold mb-4">Onboard your team effortlessly</h2>
-      <p class="mb-4">Devopsia sets up dev environments, access controls, and shared configs with zero friction.<br>Even the intern can ship by lunchtime.</p>
-      <a href="#" class="start-button bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 px-6 rounded shadow inline-block">Start building</a>
+  <section class="max-w-6xl mx-auto px-4 py-12">
+    <div class="grid items-center gap-8 md:grid-cols-2">
+      <!-- Image (left on md+) -->
+      <div class="flex justify-center md:order-1">
+        <img
+          src="/assets/Lynx_drawing_2.png"
+          alt="Lynx illustration representing easy team onboarding"
+          class="hero-img"
+          width="1200" height="1200"
+          loading="lazy" decoding="async"
+          sizes="(min-width: 1024px) 520px, (min-width: 768px) 50vw, 90vw"
+        >
+      </div>
+
+      <!-- Text (right on md+) -->
+      <div class="md:order-2">
+        <h2 class="text-2xl md:text-3xl font-semibold leading-tight">
+          Onboard your team effortlessly
+        </h2>
+        <p class="mt-4 text-gray-700">
+          Devopsia sets up dev environments, access controls, and shared configs with zero friction.<br>
+          Even the intern can ship by lunchtime.
+        </p>
+        <a href="/ai-assistant-terraform/" class="inline-block mt-6 btn-primary">Start building</a>
+      </div>
     </div>
   </section>
 
-  <section class="container mx-auto py-12 grid md:grid-cols-2 gap-8 items-center">
-    <div>
-      <h2 class="text-3xl font-extrabold mb-4">Automate your incident response</h2>
-      <p class="mb-4">From alerts to mitigation steps, let your AI engineer cut through the noise<br>and recommend the fastest path to recovery.</p>
-      <a href="#" class="start-button bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 px-6 rounded shadow inline-block">Start building</a>
+  <section class="max-w-6xl mx-auto px-4 py-12">
+    <div class="grid items-center gap-8 md:grid-cols-2">
+      <!-- Text (left) -->
+      <div>
+        <h2 class="text-2xl md:text-3xl font-semibold leading-tight">
+          Automate your incident response
+        </h2>
+        <p class="mt-4 text-gray-700">
+          From alerts to mitigation steps, let your AI engineer cut through the noise<br>
+          and recommend the fastest path to recovery.
+        </p>
+        <a href="/ai-assistant-terraform/" class="inline-block mt-6 btn-primary">Start building</a>
+      </div>
+
+      <!-- Image (right) -->
+      <div class="flex justify-center">
+        <img
+          src="/assets/Lynx_drawing_3.png"
+          alt="Lynx illustration representing incident automation"
+          class="hero-img"
+          width="1200" height="1200"
+          loading="lazy" decoding="async"
+          sizes="(min-width: 1024px) 520px, (min-width: 768px) 50vw, 90vw"
+        >
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- embed responsive Lynx illustrations alongside the three homepage hero text blocks
- add framework-agnostic `.hero-img` styles and a gradient `.btn-primary` button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad76afdf00832f83d0a8c3eed35964