### PR TITLE
Bulk update Process File button style across AI assistant pages

### DIFF
--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -132,7 +132,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -132,7 +132,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -132,7 +132,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -132,7 +132,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -131,7 +131,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -132,7 +132,7 @@
             </select>
             <label class="block text-sm text-gray-600">Instructions (for Optimize)</label>
             <textarea id="instructionsInput" class="block w-full min-h-[80px] border rounded px-3 py-2" placeholder="e.g., Keep YAML comments; sort keys if JSON."></textarea>
-            <button id="processFileBtn" class="mt-2 inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-gray-50 hover:bg-gray-100">Process File</button>
+            <button id="processFileBtn" class="mt-2 px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700">Process File</button>
           </div>
           <div class="space-y-2">
             <label class="block text-sm text-gray-600">Result</label>


### PR DESCRIPTION
## Summary
- unify Process File button styling across AI assistant docs pages
- promote button to primary action with indigo background and white text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b175172c2c832f88bc4db629cdef88