### PR TITLE
refactor: unify favicon across docs

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/ai-assistant-ansible/index.html
+++ b/docs/ai-assistant-ansible/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/ai-assistant-docker/index.html
+++ b/docs/ai-assistant-docker/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/ai-assistant-helm/index.html
+++ b/docs/ai-assistant-helm/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/ai-assistant-k8s/index.html
+++ b/docs/ai-assistant-k8s/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/ai-assistant-terraform/index.html
+++ b/docs/ai-assistant-terraform/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/ai-assistant-yaml/index.html
+++ b/docs/ai-assistant-yaml/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>[x-cloak]{display:none !important;}</style>

--- a/docs/behind-the-build/index.html
+++ b/docs/behind-the-build/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/lynx-logo.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/kits/index.html
+++ b/docs/kits/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>

--- a/docs/pricing/index.html
+++ b/docs/pricing/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -6,7 +6,7 @@
   <title>Devopsia — Product</title>
   <link rel="stylesheet" href="/css/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
 </head>
 <body>
   <div id="top-banner"></div>

--- a/docs/profile/index.html
+++ b/docs/profile/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-800">

--- a/docs/prompt-history/index.html
+++ b/docs/prompt-history/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -6,7 +6,7 @@
   <title>Devopsia — Resources</title>
   <link rel="stylesheet" href="/css/style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/Lynx Logo Design.png" type="image/png">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Montserrat&family=Bitcount+Grid+Double&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <style>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/css/style.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Sans:wght@200&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/Lynx Logo Design.png" type="image/svg+xml">
+  <link rel="icon" href="/assets/lynx-logo.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- use consistent /assets/lynx-logo.svg favicon across documentation HTML pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b182770920832f86f10b7c9090b8d5