### PR TITLE
feat(login): add hovering panel with gradient background

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -534,3 +534,62 @@ header .rounded-2xl { will-change: transform; }
     transform: translateY(-1px);
   }
 }
+
+/* ====== Login Page Background & Panel ====== */
+
+/* Large radial gradient "blob" behind the panel */
+.login-gradient-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  /* Layered radial gradients for warm, friendly glow */
+  background:
+    radial-gradient(40rem 40rem at 30% 30%, rgba(255, 183, 77, 0.45), transparent 60%),
+    radial-gradient(35rem 35rem at 70% 40%, rgba(66, 165, 245, 0.35), transparent 65%),
+    radial-gradient(30rem 30rem at 50% 70%, rgba(76, 175, 80, 0.30), transparent 65%);
+  filter: blur(20px);
+  transform: translateZ(0);
+}
+
+/* Hovering card look */
+.login-card {
+  /* sizing tuned for responsiveness; adjust as needed */
+  width: min(100%, 480px);
+  padding: 2rem;
+  /* subtle lift */
+  transform: translateZ(0);
+}
+
+/* Tiny "Home" button that sits just above-left corner of the panel */
+.login-home-btn {
+  position: absolute;
+  top: -1.75rem;   /* space above panel */
+  left: 0.25rem;   /* just off the panel's left edge */
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1rem;
+  border-radius: 9999px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: blur(4px);
+  color: #111827; /* gray-900 */
+  border: 1px solid rgba(0,0,0,0.08);
+  box-shadow: 0 6px 24px rgba(0,0,0,0.12);
+  text-decoration: none;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+.login-home-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px rgba(0,0,0,0.16);
+  background: rgba(255,255,255,0.95);
+}
+.login-home-btn:focus-visible {
+  outline: 2px solid #60a5fa; /* blue-400 */
+  outline-offset: 2px;
+}
+
+/* Motion-reduced preference */
+@media (prefers-reduced-motion: reduce) {
+  .login-home-btn {
+    transition: none;
+  }
+}

--- a/docs/login/index.html
+++ b/docs/login/index.html
@@ -18,27 +18,45 @@
     }
   </style>
 </head>
-<body class="min-h-screen flex flex-col bg-gray-50 text-gray-700">
+<body class="min-h-screen bg-gray-50 text-gray-800">
   <div id="top-banner"></div>
-    <main class="container mx-auto py-20 flex-grow flex justify-center items-start">
-    <div class="bg-gray-200 p-8 rounded-lg shadow w-full max-w-md">
-      <h1 class="text-3xl font-extrabold mb-6 text-center">Sign In to Devopsia</h1>
-      <form id="login-form" class="space-y-4">
-        <input type="email" id="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <input type="password" id="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
-        <p id="loginError" class="text-red-600 hidden"></p>
-        <button id="loginBtn" type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Login</button>
-      </form>
-      <button id="google-login" class="mt-4 w-full flex items-center justify-center gap-2 border border-gray-300 rounded py-2 bg-white hover:bg-gray-50">
-        <img src="/assets/google-icon.svg" alt="Google logo" width="20" height="20">
-        <span>Sign in with Google</span>
-      </button>
-      <button id="resend-verification" type="button" class="mt-4 w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Resend Verification Email</button>
-      <p class="mt-4 text-center text-sm">Don't have an account?
-        <a href="/signup.html" class="text-orange-600 hover:underline">Sign up</a>
-      </p>
-    </div>
+
+  <!-- Full page bg container -->
+  <main class="relative min-h-[calc(100vh-80px)] flex items-center justify-center px-4 py-10 overflow-hidden">
+    <!-- Decorative gradient blob(s) behind the panel -->
+    <div class="login-gradient-bg pointer-events-none" aria-hidden="true"></div>
+
+    <!-- Panel wrapper to allow the small Home button to sit above-left -->
+    <section class="relative">
+      <!-- Small Home button above-left of the panel -->
+      <a href="/" class="login-home-btn inline-flex items-center gap-2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        <span class="sr-only">Go to Homepage</span>
+      </a>
+
+      <!-- HOVERING LOGIN PANEL: keep the existing form markup – do not change IDs, names, or JS hooks -->
+      <div class="login-card relative z-10 rounded-2xl shadow-2xl ring-1 ring-black/5 bg-white/90 backdrop-blur-md">
+        <h1 class="text-3xl font-extrabold mb-6 text-center">Sign In to Devopsia</h1>
+        <form id="login-form" class="space-y-4">
+          <input type="email" id="email" placeholder="Email" required class="w-full border border-gray-300 rounded px-4 py-2">
+          <input type="password" id="password" placeholder="Password" required class="w-full border border-gray-300 rounded px-4 py-2">
+          <p id="loginError" class="text-red-600 hidden"></p>
+          <button id="loginBtn" type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Login</button>
+        </form>
+        <button id="google-login" class="mt-4 w-full flex items-center justify-center gap-2 border border-gray-300 rounded py-2 bg-white hover:bg-gray-50">
+          <img src="/assets/google-icon.svg" alt="Google logo" width="20" height="20">
+          <span>Sign in with Google</span>
+        </button>
+        <button id="resend-verification" type="button" class="mt-4 w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 rounded">Resend Verification Email</button>
+        <p class="mt-4 text-center text-sm">Don't have an account?
+          <a href="/signup.html" class="text-orange-600 hover:underline">Sign up</a>
+        </p>
+      </div>
+    </section>
   </main>
+
   <div id="resend-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
     <div class="bg-white p-6 rounded shadow w-full max-w-sm" role="dialog" aria-modal="true">
       <h2 class="text-xl font-bold mb-4">Resend verification</h2>
@@ -61,3 +79,4 @@
   <script src="/js/footer-loader.js" defer></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- restyle `/docs/login/index.html` with floating login card over warm circular gradient background and add a small Home button above-left
- append gradient blob, hovering card, and Home button styles to `/docs/css/style.css`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2aff7b3b8832f832914aa05479290