### PR TITLE
Homepage copy refresh - Cloud-first hero + templates messaging (preserve layout/images)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,16 +15,49 @@
   <div id="top-banner"></div>
   
   <section class="container mx-auto text-center py-12 md:py-20">
-    <h1 class="text-4xl md:text-6xl font-medium font-tagline mb-4">Your AI DevOps Engineer</h1>
-    <p class="text-lg md:text-2xl mb-10">Type your infra task. Get instant, ready-to-run code.</p>
+    <h1 class="text-4xl md:text-6xl font-medium font-tagline mb-4">Your AI DevOps Engineer — for AWS, Azure, and GCP</h1>
+    <p class="text-lg md:text-2xl mb-10">Devopsia turns your intent into secure cloud setups and proven templates—so you spend less time debugging and more time delivering.</p>
+    <ul class="mt-6 space-y-2 text-sm md:text-base text-gray-600 max-w-3xl mx-auto text-left">
+      <li class="flex items-start gap-2">
+        <span class="text-orange-500">•</span>
+        <span>Terraform/OpenTofu, Kubernetes, Helm, CI/CD, Docker, Ansible</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="text-orange-500">•</span>
+        <span>Observability (OTel, Prometheus rules) and Policy-as-code (OPA/Conftest)</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="text-orange-500">•</span>
+        <span>Includes validation commands and production-ready defaults</span>
+      </li>
+    </ul>
   </section>
 
   <div id="ai-builder" class="container mx-auto pb-16">
     <div class="w-full max-w-3xl mx-auto flex rounded-lg shadow-lg overflow-hidden">
-      <input type="text" class="flex-grow bg-gray-900/80 placeholder-gray-400 text-white font-mono text-lg md:text-xl py-4 px-6 focus:outline-none focus:ring-2 focus:ring-orange-500 transition-shadow" placeholder="Deploy a Kubernetes cluster with monitoring in AWS" />
-      <button class="start-button bg-orange-500 hover:bg-orange-600 text-white px-6 py-4 font-semibold rounded">Try a prompt</button>
+      <input type="text" class="flex-grow bg-gray-900/80 placeholder-gray-400 text-white font-mono text-lg md:text-xl py-4 px-6 focus:outline-none focus:ring-2 focus:ring-orange-500 transition-shadow" placeholder="Describe what you want to build, migrate, operate, or secure…" />
+      <button class="start-button bg-orange-500 hover:bg-orange-600 text-white px-6 py-4 font-semibold rounded">Start Building</button>
     </div>
+    <p class="mt-2 text-xs text-gray-500 text-center">Use placeholders for secrets. Devopsia will suggest secure patterns.</p>
   </div>
+
+  <section class="max-w-6xl mx-auto px-4 py-12">
+    <h2 class="text-2xl md:text-3xl font-semibold leading-tight">How it works</h2>
+    <ol class="mt-6 grid gap-4 md:grid-cols-3 text-gray-700">
+      <li class="flex items-start gap-3">
+        <span class="font-semibold text-gray-500">1.</span>
+        <span>Pick a cloud or a template</span>
+      </li>
+      <li class="flex items-start gap-3">
+        <span class="font-semibold text-gray-500">2.</span>
+        <span>Add context (env, constraints, stack)</span>
+      </li>
+      <li class="flex items-start gap-3">
+        <span class="font-semibold text-gray-500">3.</span>
+        <span>Get files + checks + gotchas — save to history</span>
+      </li>
+    </ol>
+  </section>
 
   <section class="max-w-6xl mx-auto px-4 py-12">
     <div class="grid items-center gap-8 md:grid-cols-2">
@@ -46,13 +79,17 @@
           </div>
           <div class="pt-2 border-t border-gray-100">
             <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Advanced / Templates</div>
-            <a href="/advanced/" class="inline-flex items-center px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100 font-semibold mb-3">Browse Templates</a>
+            <a href="/advanced/" class="inline-flex items-center px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100 font-semibold mb-3">Explore Templates</a>
             <div class="flex flex-wrap gap-2 text-sm">
               <a href="/advanced/terraform/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Terraform</a>
+              <a href="/advanced/kubernetes/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Kubernetes</a>
               <a href="/advanced/helm/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Helm</a>
-              <a href="/advanced/kubernetes/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Kubernetes Templates</a>
-              <a href="/advanced/ansible/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Ansible</a>
+              <a href="/advanced/github-actions/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">GitHub Actions</a>
+              <a href="/advanced/gitlab-ci/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">GitLab CI</a>
               <a href="/advanced/docker/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Docker</a>
+              <a href="/advanced/ansible/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Ansible</a>
+              <a href="/advanced/observability/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Observability</a>
+              <a href="/advanced/policy/" class="px-4 py-2 rounded-lg border border-gray-200 text-gray-800 hover:bg-gray-100">Policy-as-code</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Emphasize cloud-first capabilities and templates in the hero to clarify product value.  
- Make the prompt and security microcopy explicit about using placeholders for secrets.  
- Ensure Advanced/Templates chips display the requested labels and order for discoverability.  
- Add a short “How it works” guide to reduce friction without changing visual structure.

### Description
- Replaced the hero headline and subheadline and added the three requested bullet points under the hero.  
- Updated the primary CTA label to `Start Building` and the secondary CTA label to `Explore Templates` with the secondary CTA linking to `/advanced/`.  
- Changed the prompt input placeholder to `Describe what you want to build, migrate, operate, or secure…` and updated the security note to `Use placeholders for secrets. Devopsia will suggest secure patterns.` while keeping the prompt box in place.  
- Inserted a new `How it works` section with three numbered steps between the hero/prompt area and the feature/template listings, and updated the Advanced/Templates chips to: `Terraform • Kubernetes • Helm • GitHub Actions • GitLab CI • Docker • Ansible • Observability • Policy-as-code`, preserving all image tags, sources, positions, and responsive wrappers.

### Testing
- Served the `docs` directory locally with `python -m http.server` and loaded `index.html` in Playwright to validate rendering at `1280x720`.  
- Playwright completed page load and produced a full-page screenshot saved as `artifacts/homepage.png`.  
- Performed a visual smoke check to confirm images remained in their original DOM positions and layout was not disrupted.  
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e485e9ba0832fa8b9d743224b4832)