### PR TITLE
Add workspace file tree, diff viewer, and GitHub scaffold export

### DIFF
--- a/docs/js/ai-assistant.js
+++ b/docs/js/ai-assistant.js
@@ -1,6 +1,19 @@
 import { auth, db } from './firebase.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js';
-import { doc, getDoc, setDoc, collection, addDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+import {
+  doc,
+  getDoc,
+  setDoc,
+  collection,
+  addDoc,
+  serverTimestamp,
+  getDocs,
+  query,
+  orderBy,
+  limit
+} from 'https://www.gstatic.com/firebasejs/10.11.0/firebase-firestore.js';
+import { extractArtifactsV1 } from './artifacts/parse.js';
+import { buildWorkspacePanel } from './workspace/WorkspacePanel.js';
 
 let userPlan = 'free';
 let currentMode = 'secure';
@@ -19,6 +32,7 @@ const VALID_VALUES = {
 };
 
 const MAX_ARTIFACT_CHARS = 12000;
+let previousArtifactsV1 = null;
 
 const templateState = {
   templates: [],
@@ -263,6 +277,39 @@ function trimStructured(structured) {
     });
   }
   return clone;
+}
+
+async function fetchPreviousArtifactsV1(userId, currentRequestId) {
+  if (!userId) return null;
+  try {
+    const historyQuery = query(
+      collection(db, 'users', userId, 'prompts'),
+      orderBy('createdAt', 'desc'),
+      limit(10)
+    );
+    const snapshot = await getDocs(historyQuery);
+    for (const docSnap of snapshot.docs) {
+      const data = docSnap.data();
+      if (data?.requestId === currentRequestId) continue;
+      if (data?.artifacts_v1?.files?.length) return data.artifacts_v1;
+    }
+  } catch (err) {
+    console.error('Failed to fetch previous artifacts', err);
+  }
+  return null;
+}
+
+function renderWorkspaceSection(container, { artifactsV1, promptText, previousArtifacts } = {}) {
+  if (!container) return;
+  const existing = container.querySelector('#workspace-panel');
+  if (existing) existing.remove();
+  if (!artifactsV1?.files?.length) return;
+  const panel = buildWorkspacePanel({
+    artifacts: artifactsV1,
+    previousArtifacts,
+    promptText
+  });
+  container.appendChild(panel);
 }
 
 function renderCopyButton(text) {
@@ -743,8 +790,14 @@ document.getElementById('runPrompt').addEventListener('click', async () => {
     if (!res.ok) throw new Error('Request failed');
     const data = await res.json();
     const normalized = normalizeResponsePayload(data);
+    const artifactsV1 = extractArtifactsV1(data);
 
     renderStructuredResponse(resultEl, data);
+    renderWorkspaceSection(resultEl, {
+      artifactsV1,
+      promptText: prompt,
+      previousArtifacts: previousArtifactsV1
+    });
 
     const user = auth.currentUser;
     if (user) {
@@ -767,6 +820,7 @@ document.getElementById('runPrompt').addEventListener('click', async () => {
           response: normalized.responseText,
           responseText: normalized.responseText,
           responseStructured: trimStructured(structured),
+          artifacts_v1: artifactsV1,
           cloud: context.cloud,
           goal: context.goal,
           outputFormat: context.outputFormat,
@@ -781,6 +835,14 @@ document.getElementById('runPrompt').addEventListener('click', async () => {
           pagePath: window.location?.pathname,
           createdAt: serverTimestamp()
         });
+        if (artifactsV1?.files?.length) {
+          previousArtifactsV1 = await fetchPreviousArtifactsV1(user.uid, requestId);
+          renderWorkspaceSection(resultEl, {
+            artifactsV1,
+            promptText: prompt,
+            previousArtifacts: previousArtifactsV1
+          });
+        }
       } catch (err) {
         console.error('Failed to save prompt history', err);
       }

--- a/docs/js/artifacts/diff.js
+++ b/docs/js/artifacts/diff.js
@@ -1,0 +1,17 @@
+import { diffLines } from 'https://cdn.jsdelivr.net/npm/diff@5.2.0/+esm';
+
+function buildUnifiedDiff(previousText = '', currentText = '') {
+  const parts = diffLines(previousText, currentText);
+  const lines = [];
+  parts.forEach((part) => {
+    const type = part.added ? 'add' : part.removed ? 'remove' : 'context';
+    const split = part.value.split('\n');
+    split.forEach((line, index) => {
+      if (index === split.length - 1 && line === '') return;
+      lines.push({ type, content: line });
+    });
+  });
+  return lines;
+}
+
+export { buildUnifiedDiff };

--- a/docs/js/artifacts/exportScaffold.js
+++ b/docs/js/artifacts/exportScaffold.js
@@ -1,0 +1,97 @@
+import JSZip from 'https://cdn.jsdelivr.net/npm/jszip@3.10.1/+esm';
+
+const DEFAULT_README = (promptText) => {
+  const safePrompt = (promptText || '').trim().slice(0, 400);
+  const promptSection = safePrompt
+    ? `\n## Generated from prompt\n\n> ${safePrompt.replace(/\n/g, '\n> ')}\n`
+    : '';
+  return `# Project Scaffold\n\nGenerated with Devopsia. Review the files and adjust for your environment.\n\n## How to use\n\n1. Review the generated files.\n2. Update variables, secrets, and environment-specific values.\n3. Run your deployment or infrastructure workflow.\n${promptSection}`.trim();
+};
+
+const MIT_LICENSE = (year) => `MIT License\n\nCopyright (c) ${year} Devopsia\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.`;
+
+function detectProjectTypes(files = []) {
+  const types = new Set();
+  const paths = files.map((file) => file.path);
+
+  if (paths.some((path) => path.endsWith('.tf'))) types.add('terraform');
+  if (paths.some((path) => path.endsWith('Chart.yaml'))) types.add('helm');
+  if (paths.some((path) => /(^|\/)kustomization\.ya?ml$/.test(path))) types.add('k8s');
+  if (paths.some((path) => /(^|\/)manifests\/.*\.ya?ml$/.test(path))) types.add('k8s');
+  if (paths.some((path) => path.endsWith('package.json'))) types.add('node');
+  if (paths.some((path) => path.endsWith('pyproject.toml') || path.endsWith('requirements.txt'))) types.add('python');
+
+  return types;
+}
+
+function buildGitignore(types) {
+  const patterns = new Set();
+  if (types.has('terraform')) {
+    ['.terraform/', '*.tfstate', '*.tfstate.*', 'crash.log'].forEach((line) => patterns.add(line));
+  }
+  if (types.has('helm')) {
+    ['charts/*.tgz', '.DS_Store'].forEach((line) => patterns.add(line));
+  }
+  if (types.has('k8s')) {
+    ['.DS_Store'].forEach((line) => patterns.add(line));
+  }
+  if (types.has('node')) {
+    ['node_modules/', 'dist/', '.env'].forEach((line) => patterns.add(line));
+  }
+  if (types.has('python')) {
+    ['__pycache__/', '.venv/', '*.pyc'].forEach((line) => patterns.add(line));
+  }
+
+  return Array.from(patterns).join('\n');
+}
+
+function hasRootFile(files, name) {
+  return files.some((file) => file.path.toLowerCase() === name.toLowerCase());
+}
+
+function downloadBlob(blob, filename) {
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(link.href);
+}
+
+async function exportZip(files, filename = 'devopsia-artifacts.zip') {
+  const zip = new JSZip();
+  files.forEach((file) => {
+    zip.file(file.path, file.content || '');
+  });
+  const blob = await zip.generateAsync({ type: 'blob' });
+  downloadBlob(blob, filename);
+}
+
+async function exportScaffoldZip({ files, promptText, licenseChoice }) {
+  const zip = new JSZip();
+  files.forEach((file) => {
+    zip.file(file.path, file.content || '');
+  });
+
+  const types = detectProjectTypes(files);
+
+  if (!hasRootFile(files, 'README.md')) {
+    zip.file('README.md', DEFAULT_README(promptText));
+  }
+
+  if (!hasRootFile(files, '.gitignore')) {
+    const gitignore = buildGitignore(types);
+    if (gitignore) zip.file('.gitignore', gitignore);
+  }
+
+  if (licenseChoice && licenseChoice.toLowerCase() === 'mit' && !hasRootFile(files, 'LICENSE')) {
+    const year = new Date().getFullYear();
+    zip.file('LICENSE', MIT_LICENSE(year));
+  }
+
+  const blob = await zip.generateAsync({ type: 'blob' });
+  downloadBlob(blob, 'devopsia-github-scaffold.zip');
+}
+
+export { exportZip, exportScaffoldZip, detectProjectTypes, buildGitignore };

--- a/docs/js/artifacts/parse.js
+++ b/docs/js/artifacts/parse.js
@@ -1,0 +1,97 @@
+const ARTIFACT_LIMITS = {
+  maxFiles: 200,
+  maxTotalBytes: 1_200_000,
+  maxFileBytes: 200_000
+};
+
+function sanitizePath(input) {
+  if (!input || typeof input !== 'string') return null;
+  const normalized = input.replace(/\\/g, '/').replace(/^\/+/, '');
+  const parts = normalized.split('/').filter((part) => part && part !== '.' && part !== '..');
+  if (!parts.length) return null;
+  return parts.join('/');
+}
+
+function truncateUtf8(text, maxBytes) {
+  if (typeof text !== 'string') return '';
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(text);
+  if (bytes.length <= maxBytes) return text;
+  const truncated = bytes.slice(0, maxBytes);
+  const decoder = new TextDecoder();
+  return decoder.decode(truncated);
+}
+
+function sanitizeArtifactsV1(payload) {
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.files)) return null;
+  const encoder = new TextEncoder();
+  let totalBytes = 0;
+  const sanitized = [];
+
+  for (const entry of payload.files) {
+    if (!entry || typeof entry !== 'object') continue;
+    const path = sanitizePath(entry.path);
+    if (!path) continue;
+    const content = typeof entry.content === 'string' ? entry.content : '';
+    const mime = typeof entry.mime === 'string' ? entry.mime : '';
+    const truncatedContent = truncateUtf8(content, ARTIFACT_LIMITS.maxFileBytes);
+    const contentBytes = encoder.encode(truncatedContent).length;
+    if (totalBytes + contentBytes > ARTIFACT_LIMITS.maxTotalBytes) break;
+    totalBytes += contentBytes;
+    sanitized.push({ path, content: truncatedContent, mime });
+    if (sanitized.length >= ARTIFACT_LIMITS.maxFiles) break;
+  }
+
+  if (!sanitized.length) return null;
+  return { files: sanitized };
+}
+
+function tryParseArtifactsString(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const marker = '[DEVOPSIA_ARTIFACTS_V1]';
+  let candidate = raw.trim();
+  const markerIndex = candidate.indexOf(marker);
+  if (markerIndex >= 0) {
+    candidate = candidate.slice(markerIndex + marker.length).trim();
+  }
+  if (!candidate) return null;
+  try {
+    const parsed = JSON.parse(candidate);
+    return sanitizeArtifactsV1(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function extractArtifactsV1(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  const structured = payload.responseStructured || payload.structured || payload.structuredResponse || null;
+  const direct =
+    structured?.artifacts_v1 ||
+    structured?.artifactsV1 ||
+    payload.artifacts_v1 ||
+    payload.artifactsV1 ||
+    structured?.files ||
+    payload.files;
+  const sanitized = sanitizeArtifactsV1(direct);
+  if (sanitized) return sanitized;
+
+  const artifacts = structured?.artifacts || payload.artifacts;
+  if (Array.isArray(artifacts)) {
+    for (const item of artifacts) {
+      const content = typeof item?.content === 'string' ? item.content : item?.text || item?.body || '';
+      const parsed = tryParseArtifactsString(content);
+      if (parsed) return parsed;
+    }
+  }
+
+  const fallback = typeof payload.output === 'string' ? payload.output : payload.response || payload.text;
+  if (typeof fallback === 'string') {
+    const parsed = tryParseArtifactsString(fallback);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
+export { ARTIFACT_LIMITS, extractArtifactsV1, sanitizeArtifactsV1 };

--- a/docs/js/artifacts/tree.js
+++ b/docs/js/artifacts/tree.js
@@ -1,0 +1,57 @@
+function createNode(name, path, type) {
+  return { name, path, type, children: [] };
+}
+
+function buildArtifactTree(files = []) {
+  const root = createNode('root', '', 'folder');
+  const fileMap = new Map();
+
+  files.forEach((file) => {
+    if (!file || !file.path) return;
+    const parts = file.path.split('/').filter(Boolean);
+    let current = root;
+    parts.forEach((part, index) => {
+      const isFile = index === parts.length - 1;
+      const nextPath = current.path ? `${current.path}/${part}` : part;
+      let child = current.children.find((node) => node.name === part);
+      if (!child) {
+        child = createNode(part, nextPath, isFile ? 'file' : 'folder');
+        current.children.push(child);
+      }
+      if (isFile) {
+        child.type = 'file';
+        fileMap.set(nextPath, file);
+      }
+      current = child;
+    });
+  });
+
+  function sortTree(node) {
+    if (!node.children) return;
+    node.children.sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'folder' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    node.children.forEach(sortTree);
+  }
+
+  sortTree(root);
+  return { tree: root, fileMap };
+}
+
+function filterTree(node, query) {
+  if (!query) return node;
+  const lower = query.toLowerCase();
+  if (node.type === 'file') {
+    return node.path.toLowerCase().includes(lower) ? node : null;
+  }
+  const filteredChildren = node.children
+    .map((child) => filterTree(child, query))
+    .filter(Boolean);
+  if (filteredChildren.length) {
+    return { ...node, children: filteredChildren };
+  }
+  return node.path.toLowerCase().includes(lower) ? { ...node, children: [] } : null;
+}
+
+export { buildArtifactTree, filterTree };

--- a/docs/js/workspace/DiffViewer.js
+++ b/docs/js/workspace/DiffViewer.js
@@ -1,0 +1,56 @@
+import { buildUnifiedDiff } from '../artifacts/diff.js';
+
+function renderDiffViewer({ previousText = '', currentText = '' }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'h-full flex flex-col';
+
+  const header = document.createElement('div');
+  header.className = 'border-b border-gray-200 px-4 py-3';
+
+  const title = document.createElement('div');
+  title.className = 'text-sm font-semibold text-gray-900';
+  title.textContent = 'Diff (Previous → Generated)';
+
+  header.appendChild(title);
+
+  const contentWrap = document.createElement('div');
+  contentWrap.className = 'flex-1 overflow-auto p-4 font-mono text-xs';
+
+  const diffLines = buildUnifiedDiff(previousText, currentText);
+  if (!diffLines.length) {
+    const empty = document.createElement('div');
+    empty.className = 'text-sm text-gray-500';
+    empty.textContent = 'No differences found.';
+    contentWrap.appendChild(empty);
+  } else {
+    diffLines.forEach((line, index) => {
+      const row = document.createElement('div');
+      row.className = 'flex gap-3 px-2 py-0.5 rounded';
+      if (line.type === 'add') row.classList.add('bg-green-50', 'text-green-700');
+      if (line.type === 'remove') row.classList.add('bg-red-50', 'text-red-700');
+
+      const number = document.createElement('span');
+      number.className = 'w-10 text-right text-gray-400 select-none';
+      number.textContent = String(index + 1);
+
+      const prefix = document.createElement('span');
+      prefix.className = 'w-4 text-center text-gray-400';
+      prefix.textContent = line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' ';
+
+      const text = document.createElement('span');
+      text.className = 'flex-1 whitespace-pre-wrap break-words';
+      text.textContent = line.content;
+
+      row.appendChild(number);
+      row.appendChild(prefix);
+      row.appendChild(text);
+      contentWrap.appendChild(row);
+    });
+  }
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(contentWrap);
+  return wrapper;
+}
+
+export { renderDiffViewer };

--- a/docs/js/workspace/FileTree.js
+++ b/docs/js/workspace/FileTree.js
@@ -1,0 +1,75 @@
+function createRow({ label, depth, isSelected, isFolder, isCollapsed, onClick }) {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className =
+    'w-full flex items-center gap-2 px-2 py-1 rounded text-left text-sm hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500';
+  row.style.paddingLeft = `${depth * 16 + 8}px`;
+  if (isSelected) {
+    row.classList.add('bg-blue-50', 'text-blue-700');
+  }
+
+  const icon = document.createElement('span');
+  icon.className = 'text-xs text-gray-500';
+  if (isFolder) {
+    icon.textContent = isCollapsed ? '▸' : '▾';
+  } else {
+    icon.textContent = '•';
+  }
+
+  const text = document.createElement('span');
+  text.className = 'truncate';
+  text.textContent = label;
+
+  row.appendChild(icon);
+  row.appendChild(text);
+  row.addEventListener('click', onClick);
+  return row;
+}
+
+function renderNode(node, depth, options, container) {
+  const { selectedPath, collapsedPaths, onToggle, onSelect } = options;
+  if (node.type === 'folder') {
+    const isCollapsed = collapsedPaths.has(node.path);
+    container.appendChild(
+      createRow({
+        label: node.name || 'root',
+        depth,
+        isSelected: false,
+        isFolder: true,
+        isCollapsed,
+        onClick: () => onToggle(node.path)
+      })
+    );
+    if (!isCollapsed) {
+      node.children.forEach((child) => renderNode(child, depth + 1, options, container));
+    }
+    return;
+  }
+
+  container.appendChild(
+    createRow({
+      label: node.name,
+      depth,
+      isSelected: node.path === selectedPath,
+      isFolder: false,
+      onClick: () => onSelect(node.path)
+    })
+  );
+}
+
+function renderFileTree(tree, options) {
+  const container = document.createElement('div');
+  container.className = 'space-y-0.5';
+  if (!tree || !tree.children?.length) {
+    const empty = document.createElement('div');
+    empty.className = 'text-sm text-gray-500 px-3 py-2';
+    empty.textContent = 'No files to display.';
+    container.appendChild(empty);
+    return container;
+  }
+
+  tree.children.forEach((child) => renderNode(child, 0, options, container));
+  return container;
+}
+
+export { renderFileTree };

--- a/docs/js/workspace/FileViewer.js
+++ b/docs/js/workspace/FileViewer.js
@@ -1,0 +1,92 @@
+const DEFAULT_MAX_BYTES = 200_000;
+const DEFAULT_MAX_LINES = 4000;
+
+function buildLineNumberedContent(content) {
+  const lines = content.split('\n');
+  const container = document.createElement('div');
+  container.className = 'space-y-0.5';
+
+  lines.forEach((line, index) => {
+    const row = document.createElement('div');
+    row.className = 'flex gap-3';
+
+    const number = document.createElement('span');
+    number.className = 'w-10 text-right text-xs text-gray-400 select-none';
+    number.textContent = String(index + 1);
+
+    const text = document.createElement('span');
+    text.className = 'flex-1 whitespace-pre-wrap break-words';
+    text.textContent = line;
+
+    row.appendChild(number);
+    row.appendChild(text);
+    container.appendChild(row);
+  });
+
+  return container;
+}
+
+function renderFileViewer({ file, onCopy, onDownload, maxBytes = DEFAULT_MAX_BYTES, maxLines = DEFAULT_MAX_LINES }) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'h-full flex flex-col';
+
+  if (!file) {
+    const empty = document.createElement('div');
+    empty.className = 'text-sm text-gray-500 p-6';
+    empty.textContent = 'Select a file to preview its contents.';
+    wrapper.appendChild(empty);
+    return wrapper;
+  }
+
+  const header = document.createElement('div');
+  header.className = 'flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 px-4 py-3';
+
+  const title = document.createElement('div');
+  title.className = 'text-sm font-semibold text-gray-900 truncate';
+  title.textContent = file.path;
+
+  const actions = document.createElement('div');
+  actions.className = 'flex items-center gap-2';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.type = 'button';
+  copyBtn.className =
+    'inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50';
+  copyBtn.textContent = 'Copy';
+  copyBtn.addEventListener('click', () => onCopy(file));
+
+  const downloadBtn = document.createElement('button');
+  downloadBtn.type = 'button';
+  downloadBtn.className =
+    'inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50';
+  downloadBtn.textContent = 'Download';
+  downloadBtn.addEventListener('click', () => onDownload(file));
+
+  actions.appendChild(copyBtn);
+  actions.appendChild(downloadBtn);
+
+  header.appendChild(title);
+  header.appendChild(actions);
+
+  const contentWrap = document.createElement('div');
+  contentWrap.className = 'flex-1 overflow-auto p-4 font-mono text-xs text-gray-800';
+
+  const content = file.content || '';
+  const byteLength = new TextEncoder().encode(content).length;
+  const lineCount = content.split('\n').length;
+
+  if (byteLength > maxBytes || lineCount > maxLines) {
+    const notice = document.createElement('div');
+    notice.className = 'text-sm text-gray-500';
+    notice.textContent = 'File too large to preview. Use Download to view the full file.';
+    contentWrap.appendChild(notice);
+  } else {
+    contentWrap.appendChild(buildLineNumberedContent(content));
+  }
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(contentWrap);
+  return wrapper;
+}
+
+export { renderFileViewer };

--- a/docs/js/workspace/WorkspacePanel.js
+++ b/docs/js/workspace/WorkspacePanel.js
@@ -1,0 +1,242 @@
+import { buildArtifactTree, filterTree } from '../artifacts/tree.js';
+import { exportZip, exportScaffoldZip } from '../artifacts/exportScaffold.js';
+import { renderFileTree } from './FileTree.js';
+import { renderFileViewer } from './FileViewer.js';
+import { renderDiffViewer } from './DiffViewer.js';
+
+const SEARCH_DEBOUNCE_MS = 150;
+
+function downloadFile(file) {
+  const blob = new Blob([file.content || ''], { type: file.mime || 'text/plain' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = file.path.split('/').pop() || file.path;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(link.href);
+}
+
+function copyToClipboard(text) {
+  navigator.clipboard.writeText(text || '').catch((err) => console.error('Copy failed', err));
+}
+
+function getLicenseChoice() {
+  try {
+    return window.localStorage.getItem('devopsia.license');
+  } catch {
+    return null;
+  }
+}
+
+function buildTabs(activeTab, setTab) {
+  const tabWrap = document.createElement('div');
+  tabWrap.className = 'flex gap-2 md:hidden';
+
+  ['files', 'preview'].forEach((tab) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className =
+      'flex-1 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors';
+    if (tab === activeTab) {
+      btn.classList.add('bg-blue-600', 'text-white', 'border-blue-600');
+    } else {
+      btn.classList.add('border-gray-200', 'text-gray-600', 'hover:bg-gray-50');
+    }
+    btn.textContent = tab === 'files' ? 'Files' : 'Preview';
+    btn.addEventListener('click', () => setTab(tab));
+    tabWrap.appendChild(btn);
+  });
+
+  return tabWrap;
+}
+
+function buildWorkspacePanel({ artifacts, previousArtifacts, promptText }) {
+  const section = document.createElement('section');
+  section.id = 'workspace-panel';
+  section.className = 'mt-6 font-sans';
+
+  if (!artifacts?.files?.length) {
+    return section;
+  }
+
+  const { tree, fileMap } = buildArtifactTree(artifacts.files);
+  const previousMap = new Map();
+  (previousArtifacts?.files || []).forEach((file) => {
+    previousMap.set(file.path, file);
+  });
+
+  let selectedPath = artifacts.files[0]?.path || '';
+  let filterQuery = '';
+  let diffMode = false;
+  let activeTab = 'preview';
+  const collapsedPaths = new Set();
+
+  const panel = document.createElement('div');
+  panel.className = 'border border-gray-200 rounded-xl bg-white shadow-sm overflow-hidden';
+
+  const header = document.createElement('div');
+  header.className = 'border-b border-gray-200 px-4 py-3 space-y-3 bg-gray-50/60';
+
+  const headerTop = document.createElement('div');
+  headerTop.className = 'flex flex-wrap items-center justify-between gap-3';
+
+  const title = document.createElement('div');
+  title.className = 'text-sm font-semibold text-gray-900';
+  title.textContent = 'Workspace';
+
+  const actionWrap = document.createElement('div');
+  actionWrap.className = 'flex flex-wrap items-center gap-2';
+
+  const exportBtn = document.createElement('button');
+  exportBtn.type = 'button';
+  exportBtn.className =
+    'inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50';
+  exportBtn.textContent = 'Export ZIP';
+  exportBtn.addEventListener('click', () => exportZip(artifacts.files));
+
+  const scaffoldBtn = document.createElement('button');
+  scaffoldBtn.type = 'button';
+  scaffoldBtn.className =
+    'inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50';
+  scaffoldBtn.textContent = 'Export GitHub Scaffold';
+  scaffoldBtn.addEventListener('click', () =>
+    exportScaffoldZip({ files: artifacts.files, promptText, licenseChoice: getLicenseChoice() })
+  );
+
+  actionWrap.appendChild(exportBtn);
+  actionWrap.appendChild(scaffoldBtn);
+
+  headerTop.appendChild(title);
+  headerTop.appendChild(actionWrap);
+
+  const searchRow = document.createElement('div');
+  searchRow.className = 'flex flex-col gap-2 md:flex-row md:items-center';
+
+  const searchInput = document.createElement('input');
+  searchInput.type = 'search';
+  searchInput.placeholder = 'Search files...';
+  searchInput.className =
+    'w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500';
+
+  const viewToggle = document.createElement('button');
+  viewToggle.type = 'button';
+  viewToggle.className =
+    'inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50';
+  viewToggle.textContent = 'View: Preview';
+
+  searchRow.appendChild(searchInput);
+  searchRow.appendChild(viewToggle);
+
+  header.appendChild(headerTop);
+  header.appendChild(searchRow);
+
+  const tabRow = buildTabs(activeTab, (tab) => {
+    activeTab = tab;
+    render();
+  });
+  header.appendChild(tabRow);
+
+  const body = document.createElement('div');
+  body.className = 'flex flex-col md:flex-row h-[480px]';
+
+  const treePanel = document.createElement('div');
+  treePanel.className =
+    'md:w-[300px] border-r border-gray-200 bg-white overflow-y-auto p-3';
+
+  const viewerPanel = document.createElement('div');
+  viewerPanel.className = 'flex-1 bg-white overflow-hidden';
+
+  body.appendChild(treePanel);
+  body.appendChild(viewerPanel);
+
+  panel.appendChild(header);
+  panel.appendChild(body);
+  section.appendChild(panel);
+
+  let searchTimer;
+  searchInput.addEventListener('input', () => {
+    window.clearTimeout(searchTimer);
+    searchTimer = window.setTimeout(() => {
+      filterQuery = searchInput.value.trim();
+      render();
+    }, SEARCH_DEBOUNCE_MS);
+  });
+
+  function handleToggle(path) {
+    if (collapsedPaths.has(path)) collapsedPaths.delete(path);
+    else collapsedPaths.add(path);
+    renderTree();
+  }
+
+  function handleSelect(path) {
+    selectedPath = path;
+    diffMode = false;
+    renderViewer();
+    renderTree();
+  }
+
+  function renderTree() {
+    treePanel.innerHTML = '';
+    const filtered = filterTree(tree, filterQuery) || { children: [] };
+    treePanel.appendChild(
+      renderFileTree(filtered, {
+        selectedPath,
+        collapsedPaths,
+        onToggle: handleToggle,
+        onSelect: handleSelect
+      })
+    );
+  }
+
+  function renderViewer() {
+    viewerPanel.innerHTML = '';
+    const file = fileMap.get(selectedPath);
+    const previousFile = previousMap.get(selectedPath);
+    const canDiff = Boolean(previousFile);
+
+    viewToggle.disabled = !canDiff;
+    viewToggle.textContent = `View: ${diffMode ? 'Diff' : 'Preview'}`;
+
+    if (diffMode && canDiff) {
+      viewerPanel.appendChild(renderDiffViewer({ previousText: previousFile.content || '', currentText: file?.content || '' }));
+      return;
+    }
+
+    viewerPanel.appendChild(
+      renderFileViewer({
+        file,
+        onCopy: (selected) => copyToClipboard(selected.content || ''),
+        onDownload: downloadFile
+      })
+    );
+  }
+
+  viewToggle.addEventListener('click', () => {
+    if (!previousMap.has(selectedPath)) return;
+    diffMode = !diffMode;
+    renderViewer();
+  });
+
+  function render() {
+    const isFilesTab = activeTab === 'files';
+    treePanel.classList.toggle('hidden', !isFilesTab && window.innerWidth < 768);
+    viewerPanel.classList.toggle('hidden', isFilesTab && window.innerWidth < 768);
+    renderTree();
+    renderViewer();
+  }
+
+  const handleResize = () => {
+    if (!section.isConnected) {
+      window.removeEventListener('resize', handleResize);
+      return;
+    }
+    render();
+  };
+  window.addEventListener('resize', handleResize);
+  render();
+
+  return section;
+}
+
+export { buildWorkspacePanel };

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,0 +1,34 @@
+# Workspace Artifacts (V1)
+
+## Artifacts payload format
+
+The workspace reads artifacts encoded with the `DEVOPSIA_ARTIFACTS_V1` payload shape:
+
+```json
+{ "files": [ { "path": "relative/path.ext", "content": "...", "mime": "..." } ] }
+```
+
+The parser accepts payloads directly on the structured response (`artifacts_v1`, `artifactsV1`, or `files`) or in an artifact body that contains the JSON payload (optionally prefixed by `[DEVOPSIA_ARTIFACTS_V1]`). Each file path is normalized to a safe, relative path and file sizes are capped to prevent oversized payloads.
+
+## Tree building
+
+File paths are split on `/` to build a folder/file tree. Folders are sorted before files, and names are sorted alphabetically. The tree builder also returns a `Map` keyed by path for fast lookups when rendering the viewer pane.
+
+## Diff logic
+
+When a new run is saved, the client fetches the most recent prior run for the same user that contains `artifacts_v1`. If a selected file path exists in both runs, the Workspace enables a diff toggle. Diff rendering uses line-level comparisons and shows a unified diff with added/removed line highlights.
+
+## GitHub scaffold export rules
+
+The GitHub scaffold export builds a ZIP file containing the artifact files plus optional repository conventions:
+
+* `README.md` is generated if missing, with a short “How to use” section and an optional excerpt of the user prompt.
+* `.gitignore` is generated if missing, with patterns based on detected project types:
+  * Terraform (`.tf` files)
+  * Helm (`Chart.yaml`)
+  * Kubernetes (`kustomization.yaml`, or `manifests/*.yaml`)
+  * Node (`package.json`)
+  * Python (`pyproject.toml` or `requirements.txt`)
+* `LICENSE` is included only when the user has previously set a license choice in local storage (MIT only).
+
+All exports are generated client-side without server dependencies to keep static-host compatibility.


### PR DESCRIPTION
### Motivation

- Provide a Base44-like client-side Workspace for artifact runs so users can browse generated files, preview content, and compare with previous runs entirely in the browser.
- Keep the implementation static-host compatible (no server bundling) and preserve existing assistant layout and responsiveness while adding export capabilities.

### Description

- Add artifact parsing and sanitization with size/file limits via `docs/js/artifacts/parse.js` and expose `extractArtifactsV1` for the assistant.
- Implement tree construction and filtering in `docs/js/artifacts/tree.js` and a unified line-diff generator using the `diff` library in `docs/js/artifacts/diff.js`.
- Add client-side ZIP export and a GitHub scaffold builder (README/.gitignore/LICENSE heuristics) in `docs/js/artifacts/exportScaffold.js` that uses `JSZip` from a CDN.
- Create Workspace UI components `FileTree`, `FileViewer`, `DiffViewer` and `WorkspacePanel` under `docs/js/workspace/` implementing file tree, search, collapse/expand, per-file copy/download, mobile tabs, and a diff toggle.
- Wire Workspace into the assistant flow in `docs/js/ai-assistant.js` by extracting `artifacts_v1`, storing `artifacts_v1` in Firestore when saving runs, and fetching recent prior runs to enable path-based diffs client-side.
- Add `docs/workspace.md` documenting the artifacts V1 format, tree building, diff behavior, and scaffold export rules.

### Testing

- Started a local static server with `python -m http.server 4173` and confirmed the new JS assets were served (GET requests for the added modules succeeded), so static hosting and file loading validated (succeeded).
- Ran a headless browser smoke script with Playwright to render the workspace and capture a screenshot, but the Chromium process crashed with SIGSEGV in this environment, so the visual smoke test failed (failed).
- No unit tests were executed as part of this change (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f44fdf364832f974e53a7720f6aa5)